### PR TITLE
Fixed wrong usage of get_groups in q2z.

### DIFF
--- a/functions/ZZ/q2z.c
+++ b/functions/ZZ/q2z.c
@@ -1052,7 +1052,7 @@ bravais_TYP **q2z(bravais_TYP *G,
    }
 
    if (!ADFLAG){
-      GROUPS = get_groups(ADGROUPS,ad_no,number);
+      GROUPS = get_groups(ADGROUPS,ad_no,&number);
    }
 
    /* clean up */


### PR DESCRIPTION
Last argument of get_groups was an int instead of its address,
leading in some cases to an uninitialized variable, which then
results in a silly numbering of Z-classes.