### PR TITLE
Set up AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,41 @@
+# set clone depth
+clone_depth: 5                  # clone entire repository history if not defined
+
+environment:
+  TEST_SUITES: run_all
+
+  # To test building GAP both using the bundled libraries (zlib and GMP), as
+  # well as using the versions distributed with cygwin, we do the former in
+  # the 32 bit build and the latter in the 64 bit build. B
+  matrix:
+    - CYG_ARCH: x86
+      CYG_ROOT: C:\cygwin
+      ABI: 32
+      PACKAGES: "-P libgmp-devel"
+      CFLAGS: "--coverage"
+      LDFLAGS: "--coverage"
+    - CYG_ARCH: x86_64
+      CYG_ROOT: C:\cygwin64
+      PACKAGES: "-P libgmp-devel"
+      CFLAGS: "--coverage"
+      LDFLAGS: "--coverage"
+
+install:
+  - '%CYG_ROOT%\setup-%CYG_ARCH%.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l %CYG_ROOT%/var/cache/setup %PACKAGES%'
+
+# scripts that run after cloning repository
+build_script:
+  - SET "PATH=%CYG_ROOT%\bin;%PATH%"
+  # temporary hacks with sed until we will have a proper configure script
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && sed -i 's|TOPDIR=/path/to/the/directory/containing/this/makefile|TOPDIR=/cygdrive/c/projects/carat|g' Makefile"
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && sed -i 's|CFLAGS = -g -Wall -DDIAG1|CFLAGS = --coverage -g -Wall -DDIAG1|g' Makefile"
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && make"
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && cd bin; ln -s `ls -d */` carat"
+
+test_script:
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && cd tst; ./run_all.sh"
+
+on_success:
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && gcov functions/*/*.c"
+  - curl -s https://codecov.io/bash > codecov.sh
+  - bash -lc "cd $APPVEYOR_BUILD_FOLDER && ./codecov.sh"


### PR DESCRIPTION
I have started to set up AppVeyor in a hope that we may get Carat available on Windows. At the moment, it fails at the stage of cloning the repository:
```
Build started
git clone -q --depth=5 --branch=setup-appveyor https://github.com/alex-konovalov/carat.git C:\projects\carat
error: unable to stat just-written file src/con.c: No such file or directory
error: unable to stat just-written file tex/progs/Con.html: No such file or directory
fatal: unable to checkout working tree
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry the checkout with 'git checkout -f HEAD'
Command exited with code 128
```
(see e.g. https://ci.appveyor.com/project/alex-konovalov/carat/builds/20691298/job/tn0qge10n5lo37en) due to the problem described at https://github.com/gap-packages/carat/issues/5 and https://github.com/gap-system/gap-distribution/issues/55. We need to rename files first.

I have also asked the owner of lbfm-rwth organisation to permit AppVeyor integration, so if you see that request, this is where it comes from.