### PR TITLE
Convert README to Markdown and add CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-Dear user,
+[![Travis build Status](https://travis-ci.org/lbfm-rwth/carat.svg?branch=master)](https://travis-ci.org/lbfm-rwth/carat)
+[![AppVeyor build Status](https://ci.appveyor.com/api/projects/status/github/lbfm-rwth/carat?branch=master&svg=true)](https://ci.appveyor.com/project/lbfm-rwth/carat)
+[![Code Coverage](https://codecov.io/github/lbfm-rwth/carat/coverage.svg?branch=master&token=)](https://codecov.io/gh/lbfm-rwth/carat)
 
-CARAT is a package for solving certain problems in mathematical
+# CARAT 
+
+Carat is a package for solving certain problems in mathematical
 crystallography.
 
 It is distributed via
+
      Lehrstuhl B fuer Mathematik
      RWTH-Aachen
      Prof. Plesken
@@ -19,22 +24,31 @@ NOTE: CARAT was developed for crystallographic groups in dimensions up to 6.
 INSTALLATION:
 
 Just edit the Makefile in the directory you installed CARAT in, and
-change the variables 
+change the variables
+ 
      TOPDIR (which is the output of pwd when in the directory this makefile is stored in)
      CFLAGS
+
 according to your needs. Some additional explanations/examples are given
 there.
-For Mac users only: You need to delete the line "#include <malloc.h>" from include/typedef.h. This will be fixed once there is 
-a configure script.
+
+For Mac users only: You need to delete the line 
+
+    #include <malloc.h>
+    
+from `include/typedef.h`. This will be fixed once there is 
+a `configure` script.
 
 Afterwards just do
-   % make
+
+    make
+
 or to be sure everything is made from scratch:
-   % make clean ; make 
+
+    make clean ; make 
 
 If you have any problems installing CARAT, please feel free to contact
-me under
-   carat@momo.math.rwth-aachen.de
+me at carat@momo.math.rwth-aachen.de
 
 Faithfully yours
 


### PR DESCRIPTION
`.md` file is better rendered on GitHub, and badges allow to easily navigate to Travis CI, AppVeyor and Codecov pages for CARAT. You can see how it will look after this PR at https://github.com/alex-konovalov/carat/tree/readme-markdown.