### PR TITLE
Reduce command line defines

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -8,9 +8,7 @@ SRC = $(TOPDIR)/src
 INCL = $(TOPDIR)/include
 OBJ = $(TOPDIR)/obj
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
+GLOBAL = -DTOPDIR=\"$(TOPDIR)\"
 
 COMP = $(CC) $(CFLAGS) $(GLOBAL) -I$(INCL)
 

--- a/functions/Autgrp/Makefile
+++ b/functions/Autgrp/Makefile
@@ -2,7 +2,7 @@
 OBJFLAGS = -c
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 

--- a/functions/Autgrp/Makefile
+++ b/functions/Autgrp/Makefile
@@ -4,11 +4,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) $(OBJFLAGS) $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 
 OBJS = autgrp.o\
        isometry.o\

--- a/functions/Base/Makefile
+++ b/functions/Base/Makefile
@@ -4,7 +4,7 @@ CC = gcc
 
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 

--- a/functions/Base/Makefile
+++ b/functions/Base/Makefile
@@ -6,11 +6,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 
 OBJS = base.o\
        base2.o\

--- a/functions/Bravais/Makefile
+++ b/functions/Bravais/Makefile
@@ -6,11 +6,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 
 OBJS = bravais_tools.o\
        formspace.o\

--- a/functions/Bravais/Makefile
+++ b/functions/Bravais/Makefile
@@ -4,7 +4,7 @@ CC = gcc
 
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 

--- a/functions/Contrib/Makefile
+++ b/functions/Contrib/Makefile
@@ -7,11 +7,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 
 OBJS = suche_kand.o\
        torsionfree.o

--- a/functions/Contrib/Makefile
+++ b/functions/Contrib/Makefile
@@ -5,7 +5,7 @@ CFLAGS = -fwritable-strings -DDIAG1 -g
 
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 

--- a/functions/Datei/Makefile
+++ b/functions/Datei/Makefile
@@ -5,7 +5,7 @@ CFLAGS = -fwritable-strings -DDIAG1 -g
 OBJFLAGS = -c
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
          -DATOMS=\"$(TOPDIR)/tables/atoms/\" \

--- a/functions/Getput/Makefile
+++ b/functions/Getput/Makefile
@@ -7,11 +7,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) $(OBJFLAGS) $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 
 OBJS = get_bravais.o\
        get_mat.o\

--- a/functions/Getput/Makefile
+++ b/functions/Getput/Makefile
@@ -5,7 +5,7 @@ CC = gcc
 OBJFLAGS = -c
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 

--- a/functions/Graph/Makefile
+++ b/functions/Graph/Makefile
@@ -4,7 +4,7 @@ CFLAGS = -fwritable-strings -DDIAG1 -g
 
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 

--- a/functions/Graph/Makefile
+++ b/functions/Graph/Makefile
@@ -6,11 +6,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 
 OBJS = Q_data.o\
 	graph_tools.o\

--- a/functions/Hyperbolic/Makefile
+++ b/functions/Hyperbolic/Makefile
@@ -1,6 +1,6 @@
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 

--- a/functions/Hyperbolic/Makefile
+++ b/functions/Hyperbolic/Makefile
@@ -2,11 +2,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 
 OBJS = hyp_isom.o\
        hyp_stabilizer.o

--- a/functions/Idem/Makefile
+++ b/functions/Idem/Makefile
@@ -4,7 +4,7 @@ CFLAGS = -g -fwritable-strings -DDIAG1
 
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
          -DATOMS=\"$(TOPDIR)/tables/atoms/\" \

--- a/functions/Longtools/Makefile
+++ b/functions/Longtools/Makefile
@@ -4,7 +4,7 @@ CFLAGS = -DDIAG1 -fwritable-strings -g
 
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 

--- a/functions/Longtools/Makefile
+++ b/functions/Longtools/Makefile
@@ -6,11 +6,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 
 OBJS = MP_conv_mat.o\
        MP_gauss.o\

--- a/functions/M_alloc/Makefile
+++ b/functions/M_alloc/Makefile
@@ -5,7 +5,7 @@ CC = gcc
 OBJFLAGS = -c
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/libm_alloc.a
+AR = ar rDc $(TOPDIR)/lib/libm_alloc.a
 
 COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 

--- a/functions/M_alloc/Makefile
+++ b/functions/M_alloc/Makefile
@@ -7,11 +7,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/libm_alloc.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) $(OBJFLAGS) $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 
 OBJS = m_alloc.o
 

--- a/functions/Matrix/Makefile
+++ b/functions/Matrix/Makefile
@@ -7,11 +7,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) $(OBJFLAGS) $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 
 OBJS = add_mat.o\
        col_row_ops_mat.o\

--- a/functions/Matrix/Makefile
+++ b/functions/Matrix/Makefile
@@ -5,7 +5,7 @@ CC = gcc
 OBJFLAGS = -c
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 

--- a/functions/Name/Makefile
+++ b/functions/Name/Makefile
@@ -4,7 +4,7 @@ CFLAGS = -g -fwritable-strings -DDIAG1
 
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 GLOBAL = -DTOPDIR=\"$(TOPDIR)\"
 

--- a/functions/Name/Makefile
+++ b/functions/Name/Makefile
@@ -6,9 +6,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
+GLOBAL = -DTOPDIR=\"$(TOPDIR)\"
 
 COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
 

--- a/functions/Orbit/Makefile
+++ b/functions/Orbit/Makefile
@@ -7,11 +7,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) $(OBJFLAGS) $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 
 OBJS = orb_division.o\
        orbit_alg.o\

--- a/functions/Orbit/Makefile
+++ b/functions/Orbit/Makefile
@@ -5,7 +5,7 @@ CFLAGS = -g -fwritable-strings -DDIAG1
 OBJFLAGS = -c
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 

--- a/functions/Polyeder/Makefile
+++ b/functions/Polyeder/Makefile
@@ -7,11 +7,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) $(OBJFLAGS) $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 
 OBJS = first_fuber.o\
        first_polyeder.o\

--- a/functions/Polyeder/Makefile
+++ b/functions/Polyeder/Makefile
@@ -5,7 +5,7 @@ CC = gcc
 OBJFLAGS = -c
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 

--- a/functions/Presentation/Makefile
+++ b/functions/Presentation/Makefile
@@ -7,11 +7,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/libpresentation.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) $(OBJFLAGS) $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 
 OBJS = check_base.o\
        mapped_word.o\

--- a/functions/Presentation/Makefile
+++ b/functions/Presentation/Makefile
@@ -5,7 +5,7 @@ CC = gcc
 OBJFLAGS = -c
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/libpresentation.a
+AR = ar rDc $(TOPDIR)/lib/libpresentation.a
 
 COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 

--- a/functions/Reduction/Makefile
+++ b/functions/Reduction/Makefile
@@ -2,7 +2,7 @@
 OBJFLAGS = -c
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 

--- a/functions/Reduction/Makefile
+++ b/functions/Reduction/Makefile
@@ -4,11 +4,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) $(OBJFLAGS) $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 
 OBJS = mink_red.o\
        pair_red.o\

--- a/functions/Sort/Makefile
+++ b/functions/Sort/Makefile
@@ -4,11 +4,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) $(OBJFLAGS) $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 
 OBJS = compare.o\
        quicksort.o\

--- a/functions/Sort/Makefile
+++ b/functions/Sort/Makefile
@@ -2,7 +2,7 @@
 OBJFLAGS = -c
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 

--- a/functions/Symm/Makefile
+++ b/functions/Symm/Makefile
@@ -5,7 +5,7 @@ CFLAGS = -fwritable-strings -DDIAG1 -g
 OBJFLAGS = -c
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 

--- a/functions/Symm/Makefile
+++ b/functions/Symm/Makefile
@@ -7,11 +7,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) $(OBJFLAGS) $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 
 OBJS = dsylv.o\
        rest_short.o\

--- a/functions/TSubgroups/Makefile
+++ b/functions/TSubgroups/Makefile
@@ -4,7 +4,7 @@ CFLAGS = -fwritable-strings -DDIAG1 -g
 
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 GLOBAL = -DTOPDIR=\"$(TOPDIR)\"
 

--- a/functions/TSubgroups/Makefile
+++ b/functions/TSubgroups/Makefile
@@ -6,9 +6,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
+GLOBAL = -DTOPDIR=\"$(TOPDIR)\"
 
 COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
 

--- a/functions/Tools/Makefile
+++ b/functions/Tools/Makefile
@@ -2,7 +2,7 @@
 OBJFLAGS = -c
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 

--- a/functions/Tools/Makefile
+++ b/functions/Tools/Makefile
@@ -4,11 +4,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) $(OBJFLAGS) $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 
 OBJS = chin_remainder.o\
        intpow.o\

--- a/functions/Voronoi/Makefile
+++ b/functions/Voronoi/Makefile
@@ -4,7 +4,7 @@ CC = gcc
 
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 

--- a/functions/Voronoi/Makefile
+++ b/functions/Voronoi/Makefile
@@ -6,11 +6,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 
 OBJS = all_vor_neighbours.o\
        bravais_flok.o\
@@ -23,7 +19,7 @@ OBJS = all_vor_neighbours.o\
        red_normal.o\
        vor_neighbour.o\
        vor_vertices.o
-      
+
 .c.o:
 	$(COMP) $< -o $@
 

--- a/functions/ZZ/Makefile
+++ b/functions/ZZ/Makefile
@@ -6,11 +6,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 
 OBJS = ZZ.o\
        ZZ_cen_fun.o\

--- a/functions/ZZ/Makefile
+++ b/functions/ZZ/Makefile
@@ -4,7 +4,7 @@ CFLAGS = -fwritable-strings -DDIAG1 -g
 
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 

--- a/functions/Zassen/Makefile
+++ b/functions/Zassen/Makefile
@@ -5,7 +5,7 @@ CFLAGS = -fwritable-strings -DDIAG1 -g
 
 INCL = $(TOPDIR)/include
 
-AR = ar rvuc $(TOPDIR)/lib/functions.a
+AR = ar rDc $(TOPDIR)/lib/functions.a
 
 COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 

--- a/functions/Zassen/Makefile
+++ b/functions/Zassen/Makefile
@@ -7,11 +7,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rvuc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 
 OBJS = coboundary.o\
        cong_solve.o\


### PR DESCRIPTION
This PR removes unnecessary command line defines, thus reducing the length of the lines in the compilation log. Moreover, the `ar` command is now deterministic (avoiding warnings) and non-verbose (also reducing the compilation log).