### PR TITLE
Remove "just"s from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ NOTE: CARAT was developed for crystallographic groups in dimensions up to 6.
 
 INSTALLATION:
 
-Just edit the Makefile in the directory you installed CARAT in, and
+Edit the Makefile in the directory you installed CARAT in, and
 change the variables
  
      TOPDIR (which is the output of pwd when in the directory this makefile is stored in)
@@ -39,7 +39,7 @@ For Mac users only: You need to delete the line
 from `include/typedef.h`. This will be fixed once there is 
 a `configure` script.
 
-Afterwards just do
+Afterwards do
 
     make
 


### PR DESCRIPTION
In these cases the word "just" conveys that we consider these steps to
be trivial. There are lots of people who may never have compiled code
before and feel intimidated by Makefiles. Using "just" serves no
real purpose and has the side-effect of intimidating such users even more.