### PR TITLE
Make CARAT relocatable.

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -7,10 +7,9 @@ LIB = -L$(TOPDIR)/lib -lpresentation -lfunctions -lpresentation -lgmp -lm_alloc 
 SRC = $(TOPDIR)/src
 INCL = $(TOPDIR)/include
 OBJ = $(TOPDIR)/obj
+LIBS = $(TOPDIR)/lib/libpresentation.a $(TOPDIR)/lib/functions.a  $(TOPDIR)/lib/libm_alloc.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\"
-
-COMP = $(CC) $(CFLAGS) $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) -I$(INCL)
 
 ALL: DIR
 
@@ -52,454 +51,454 @@ DIR: ./Makefile ./config.guess
 
 #-------------------------------------------------------------
 
-Add:  $(SRC)/add.c
+Add:  $(SRC)/add.c $(LIBS)
 	$(COMP) -o Add \
         $(SRC)/add.c  $(LIB)
 
-Aut_grp:  $(SRC)/autgrp.c
+Aut_grp:  $(SRC)/autgrp.c $(LIBS)
 	$(COMP) -o Aut_grp \
         $(SRC)/autgrp.c  $(LIB)
 
-Bravais_equiv:  $(SRC)/bravais_equiv.c
+Bravais_equiv:  $(SRC)/bravais_equiv.c $(LIBS)
 	$(COMP) -o Bravais_equiv \
         $(SRC)/bravais_equiv.c  $(LIB)
 
-Bravais_grp:  $(SRC)/bravaisgroup.c
+Bravais_grp:  $(SRC)/bravaisgroup.c $(LIBS)
 	$(COMP) -o Bravais_grp \
         $(SRC)/bravaisgroup.c  $(LIB)
 
-Bravais_inclusions:  $(SRC)/bravais_inclusions.c
+Bravais_inclusions:  $(SRC)/bravais_inclusions.c $(LIBS)
 	$(COMP) -o Bravais_inclusions \
         $(SRC)/bravais_inclusions.c  $(LIB)
 
-Conj:  $(SRC)/conj.c
+Conj:  $(SRC)/conj.c $(LIBS)
 	$(COMP) -o Conj \
         $(SRC)/conj.c  $(LIB)
 
-Conjugated:  $(SRC)/conjugated.c
+Conjugated:  $(SRC)/conjugated.c $(LIBS)
 	$(COMP) -o Conjugated \
         $(SRC)/conjugated.c  $(LIB)
 
-Conj_bravais:  $(SRC)/conj_bravais.c
+Conj_bravais:  $(SRC)/conj_bravais.c $(LIBS)
 	$(COMP) -o Conj_bravais \
         $(SRC)/conj_bravais.c  $(LIB)
 
-Conv:  $(SRC)/conv.c
+Conv:  $(SRC)/conv.c $(LIBS)
 	$(COMP) -o Conv \
         $(SRC)/conv.c  $(LIB)
 
-Datei:  $(SRC)/datei.c
+Datei:  $(SRC)/datei.c $(LIBS)
 	$(COMP) -o Datei \
         $(SRC)/datei.c  $(LIB)
 	rm -f Bravais_catalog
 	ln -f -s Datei Bravais_catalog
 
-Elt:  $(SRC)/elt.c
+Elt:  $(SRC)/elt.c $(LIBS)
 	$(COMP) -o Elt \
         $(SRC)/elt.c  $(LIB)
 
-Extract:  $(SRC)/extract.c
+Extract:  $(SRC)/extract.c $(LIBS)
 	$(COMP) -o Extract \
         $(SRC)/extract.c  $(LIB)
 	rm -f Standard_affine_form
 	ln -f -s Extract Standard_affine_form
 
-Extensions:  $(SRC)/extensions.c
+Extensions:  $(SRC)/extensions.c $(LIBS)
 	$(COMP) -o Extensions \
         $(SRC)/extensions.c  $(LIB)
 	rm -f Vector_systems
 	ln -f -s Extensions Vector_systems
 
-First_perfect:  $(SRC)/first_perfect.c
+First_perfect:  $(SRC)/first_perfect.c $(LIBS)
 	$(COMP) -o First_perfect \
         $(SRC)/first_perfect.c  $(LIB)
 
-Form_space:  $(SRC)/form_space.c
+Form_space:  $(SRC)/form_space.c $(LIBS)
 	$(COMP) -o Form_space \
         $(SRC)/form_space.c  $(LIB)
 
-Form_elt: $(SRC)/form_elt.c
+Form_elt: $(SRC)/form_elt.c $(LIBS)
 	$(COMP) -o Form_elt \
         $(SRC)/form_elt.c  $(LIB)
 
-Formtovec:  $(SRC)/formtovec.c
+Formtovec:  $(SRC)/formtovec.c $(LIBS)
 	$(COMP) -o Formtovec \
         $(SRC)/formtovec.c  $(LIB)
 
-Full:  $(SRC)/full.c
+Full:  $(SRC)/full.c $(LIBS)
 	$(COMP) -o Full \
         $(SRC)/full.c  $(LIB)
 
-#Fundamental_domain:  $(SRC)/fundamental_domain.c
+#Fundamental_domain:  $(SRC)/fundamental_domain.c $(LIBS)
 #	$(COMP) -o Fundamental_domain \
 #        $(SRC)/fundamental_domain.c  $(LIB)
 
-Gauss:  $(SRC)/gauss.c
+Gauss:  $(SRC)/gauss.c $(LIBS)
 	$(COMP) -o Gauss \
         $(SRC)/gauss.c  $(LIB)
 
-Graph:  $(SRC)/graph.c
+Graph:  $(SRC)/graph.c $(LIBS)
 	$(COMP) -o Graph \
         $(SRC)/graph.c  $(LIB)
 
-#Gittstab:  $(SRC)/gittstab.c
+#Gittstab:  $(SRC)/gittstab.c $(LIBS)
 #	$(COMP) -o Gittstab \
 #        $(SRC)/gittstab.c  $(LIB)
 
-#Hypisom:  $(SRC)/hypisom.c
+#Hypisom:  $(SRC)/hypisom.c $(LIBS)
 #	$(COMP) -o Hypisom \
 #        $(SRC)/hypisom.c  $(LIB)
 #
-#Hypstab:  $(SRC)/hypstab.c
+#Hypstab:  $(SRC)/hypstab.c $(LIBS)
 #	$(COMP) -o Hypstab \
 #        $(SRC)/hypstab.c  $(LIB)
 
-Idem:  $(SRC)/idem.c
+Idem:  $(SRC)/idem.c $(LIBS)
 	$(COMP) -o Idem \
         $(SRC)/idem.c  $(LIB)
 
-Inv:  $(SRC)/inv.c
+Inv:  $(SRC)/inv.c $(LIBS)
 	$(COMP) -o Inv \
         $(SRC)/inv.c  $(LIB)
 
-Invar_space:  $(SRC)/invar_space.c
+Invar_space:  $(SRC)/invar_space.c $(LIBS)
 	$(COMP) -o Invar_space \
         $(SRC)/invar_space.c  $(LIB)
 
-Isometry:  $(SRC)/isometry.c
+Isometry:  $(SRC)/isometry.c $(LIBS)
 	$(COMP) -o Isometry \
         $(SRC)/isometry.c  $(LIB)
 
-Is_finite:  $(SRC)/is_finite.c
+Is_finite:  $(SRC)/is_finite.c $(LIBS)
 	$(COMP) -o Is_finite \
         $(SRC)/is_finite.c  $(LIB)
 
-Kron:  $(SRC)/kron.c
+Kron:  $(SRC)/kron.c $(LIBS)
 	$(COMP) -o Kron \
         $(SRC)/kron.c  $(LIB)
 
-KSubgroups:  $(SRC)/sub-k-groups.c
+KSubgroups:  $(SRC)/sub-k-groups.c $(LIBS)
 	$(COMP) -o KSubgroups \
         $(SRC)/sub-k-groups.c  $(LIB)
 
-KSupergroups:  $(SRC)/super-k-groups.c
+KSupergroups:  $(SRC)/super-k-groups.c $(LIBS)
 	$(COMP) -o KSupergroups \
         $(SRC)/super-k-groups.c  $(LIB)
 
-Long_solve:  $(SRC)/long_solve.c
+Long_solve:  $(SRC)/long_solve.c $(LIBS)
 	$(COMP) -o Long_solve \
         $(SRC)/long_solve.c  $(LIB)
 
-Ltm:  $(SRC)/ltm.c
+Ltm:  $(SRC)/ltm.c $(LIBS)
 	$(COMP) -o Ltm \
         $(SRC)/ltm.c  $(LIB)
 
-Modp:  $(SRC)/modp.c
+Modp:  $(SRC)/modp.c $(LIBS)
 	$(COMP) -o Modp \
         $(SRC)/modp.c  $(LIB)
 
-Mtl:  $(SRC)/mtl.c
+Mtl:  $(SRC)/mtl.c $(LIBS)
 	$(COMP) -o Mtl \
         $(SRC)/mtl.c  $(LIB)
 
-Mink_red:  $(SRC)/mink_red.c
+Mink_red:  $(SRC)/mink_red.c $(LIBS)
 	$(COMP) -o Mink_red \
         $(SRC)/mink_red.c  $(LIB)
 
-Minpol:  $(SRC)/minpol.c
+Minpol:  $(SRC)/minpol.c $(LIBS)
 	$(COMP) -o Minpol \
         $(SRC)/minpol.c  $(LIB)
 
-Mul:  $(SRC)/mul.c
+Mul:  $(SRC)/mul.c $(LIBS)
 	$(COMP) -o Mul \
         $(SRC)/mul.c  $(LIB)
 
-Name:  $(SRC)/name.c
+Name:  $(SRC)/name.c $(LIBS)
 	$(COMP) -o Name \
         $(SRC)/name.c  $(LIB)
 
-Normalizer:  $(SRC)/normalizer.c
+Normalizer:  $(SRC)/normalizer.c $(LIBS)
 	$(COMP) -o Normalizer \
         $(SRC)/normalizer.c  $(LIB)
 
-Normalizer_in_N:  $(SRC)/normalizer_in_n.c
+Normalizer_in_N:  $(SRC)/normalizer_in_n.c $(LIBS)
 	$(COMP) -o Normalizer_in_N \
         $(SRC)/normalizer_in_n.c  $(LIB)
 
-Normlin:  $(SRC)/normlin.c
+Normlin:  $(SRC)/normlin.c $(LIBS)
 	$(COMP) -o Normlin \
         $(SRC)/normlin.c  $(LIB)
 
-Orbit:  $(SRC)/orbit.c
+Orbit:  $(SRC)/orbit.c $(LIBS)
 	$(COMP) -o Orbit \
         $(SRC)/orbit.c  $(LIB)
 
-#Orbit_representatives:  $(SRC)/orbit_representatives.c
+#Orbit_representatives:  $(SRC)/orbit_representatives.c $(LIBS)
 #	$(COMP) -o Orbit_representatives \
 #        $(SRC)/orbit_representatives.c  $(LIB)
 
-#Orbrep:  $(SRC)/orbrep.c
+#Orbrep:  $(SRC)/orbrep.c $(LIBS)
 #	$(COMP) -o Orbrep \
 #        $(SRC)/orbrep.c  $(LIB)
 
-Order:  $(SRC)/order.c
+Order:  $(SRC)/order.c $(LIBS)
 	$(COMP) -o Order \
         $(SRC)/order.c  $(LIB)
 
-Pair_red:  $(SRC)/pair_red.c
+Pair_red:  $(SRC)/pair_red.c $(LIBS)
 	$(COMP) -o Pair_red \
         $(SRC)/pair_red.c  $(LIB)
 
-Pdet:  $(SRC)/pdet.c
+Pdet:  $(SRC)/pdet.c $(LIBS)
 	$(COMP) -o Pdet \
         $(SRC)/pdet.c  $(LIB)
 
-Perfect_neighbours:  $(SRC)/perfect_neighbours.c
+Perfect_neighbours:  $(SRC)/perfect_neighbours.c $(LIBS)
 	$(COMP) -o Perfect_neighbours \
         $(SRC)/perfect_neighbours.c  $(LIB)
 
-#Poincare:  $(SRC)/poincare.c
+#Poincare:  $(SRC)/poincare.c $(LIBS)
 #	$(COMP) -o Poincare \
 #        $(SRC)/poincare.c  $(LIB)
 
-Polyeder:  $(SRC)/polyeder.c
+Polyeder:  $(SRC)/polyeder.c $(LIBS)
 	$(COMP) -o Polyeder \
         $(SRC)/polyeder.c  $(LIB)
 
-P_lse_solve:  $(SRC)/p_lse_solve.c
+P_lse_solve:  $(SRC)/p_lse_solve.c $(LIBS)
 	$(COMP) -o P_lse_solve \
         $(SRC)/p_lse_solve.c  $(LIB)
 
-Q_catalog:  $(SRC)/Q_catalog.c
+Q_catalog:  $(SRC)/Q_catalog.c $(LIBS)
 	$(COMP) -o Q_catalog \
         $(SRC)/Q_catalog.c  $(LIB)
 
-QtoZ:  $(SRC)/qtoz.c
+QtoZ:  $(SRC)/qtoz.c $(LIBS)
 	$(COMP) -o QtoZ \
         $(SRC)/qtoz.c  $(LIB)
 
-Presentation:  $(SRC)/presentation.c
+Presentation:  $(SRC)/presentation.c $(LIBS)
 	$(COMP) -o Presentation \
         $(SRC)/presentation.c $(LIB)
 
-Red_gen:  $(SRC)/red_gen.c
+Red_gen:  $(SRC)/red_gen.c $(LIBS)
 	$(COMP) -o Red_gen \
         $(SRC)/red_gen.c  $(LIB)
 
-Rein:  $(SRC)/rein.c
+Rein:  $(SRC)/rein.c $(LIBS)
 	$(COMP) -o Rein \
         $(SRC)/rein.c  $(LIB)
 
-Rest_short:  $(SRC)/rest_short.c
+Rest_short:  $(SRC)/rest_short.c $(LIBS)
 	$(COMP) -o Rest_short \
         $(SRC)/rest_short.c  $(LIB)
 
-Rform:  $(SRC)/rform.c
+Rform:  $(SRC)/rform.c $(LIBS)
 	$(COMP) -o Rform \
         $(SRC)/rform.c  $(LIB)
 
-Reverse_name:  $(SRC)/reverse_name.c
+Reverse_name:  $(SRC)/reverse_name.c $(LIBS)
 	$(COMP) -o Reverse_name \
         $(SRC)/reverse_name.c  $(LIB)
 
-Same_generators:  $(SRC)/same_generators.c
+Same_generators:  $(SRC)/same_generators.c $(LIBS)
 	$(COMP) -o Same_generators \
         $(SRC)/same_generators.c  $(LIB)
 
-Scalarmul:  $(SRC)/scalarmul.c
+Scalarmul:  $(SRC)/scalarmul.c $(LIBS)
 	$(COMP) -o Scalarmul \
         $(SRC)/scalarmul.c  $(LIB)
 
-Scpr:  $(SRC)/scpr.c
+Scpr:  $(SRC)/scpr.c $(LIBS)
 	$(COMP) -o Scpr \
         $(SRC)/scpr.c  $(LIB)
 
-Short:  $(SRC)/short.c
+Short:  $(SRC)/short.c $(LIBS)
 	$(COMP) -o Short \
         $(SRC)/short.c  $(LIB)
 
-Shortest:  $(SRC)/shortest.c
+Shortest:  $(SRC)/shortest.c $(LIBS)
 	$(COMP) -o Shortest \
         $(SRC)/shortest.c  $(LIB)
 
-Short_reduce:  $(SRC)/short_reduce.c
+Short_reduce:  $(SRC)/short_reduce.c $(LIBS)
 	$(COMP) -o Short_reduce \
         $(SRC)/short_reduce.c  $(LIB)
 
-Signature:  $(SRC)/signature.c
+Signature:  $(SRC)/signature.c $(LIBS)
 	$(COMP) -o Signature \
         $(SRC)/signature.c  $(LIB)
 
-Simplify_mat:  $(SRC)/simplify_mat.c
+Simplify_mat:  $(SRC)/simplify_mat.c $(LIBS)
 	$(COMP) -o Simplify_mat \
         $(SRC)/simplify_mat.c  $(LIB)
 
-#Solve:  $(SRC)/solve.c
+#Solve:  $(SRC)/solve.c $(LIBS)
 #	$(COMP) -o Solve\
 #        $(SRC)/solve.c  $(LIB)
 
-Symbol:  $(SRC)/symbol.c
+Symbol:  $(SRC)/symbol.c $(LIBS)
 	$(COMP) -o Symbol \
         $(SRC)/symbol.c  $(LIB)
 	rm -f Bravais_type
 	ln -f -s Symbol Bravais_type
 
-TSubgroups:  $(SRC)/tsubgroups.c
+TSubgroups:  $(SRC)/tsubgroups.c $(LIBS)
 	$(COMP) -o TSubgroups \
         $(SRC)/tsubgroups.c  $(LIB)
 
-TSupergroups:  $(SRC)/tsupergroups.c
+TSupergroups:  $(SRC)/tsupergroups.c $(LIBS)
 	$(COMP) -o TSupergroups \
         $(SRC)/tsupergroups.c  $(LIB)
 
-Torsionfree:  $(SRC)/torsionfree.c
+Torsionfree:  $(SRC)/torsionfree.c $(LIBS)
 	$(COMP) -o Torsionfree \
         $(SRC)/torsionfree.c  $(LIB)
 
-Tr:  $(SRC)/tr.c
+Tr:  $(SRC)/tr.c $(LIBS)
 	$(COMP) -o Tr \
         $(SRC)/tr.c  $(LIB)
 
-Trace:  $(SRC)/trace.c
+Trace:  $(SRC)/trace.c $(LIBS)
 	$(COMP) -o Trace \
         $(SRC)/trace.c  $(LIB)
 
-Trbifo:  $(SRC)/trbifo.c
+Trbifo:  $(SRC)/trbifo.c $(LIBS)
 	$(COMP) -o Trbifo \
         $(SRC)/trbifo.c  $(LIB)
 
-Tr_bravais:  $(SRC)/tr_bravais.c
+Tr_bravais:  $(SRC)/tr_bravais.c $(LIBS)
 	$(COMP) -o Tr_bravais \
         $(SRC)/tr_bravais.c  $(LIB)
 
-Vor_vertices:  $(SRC)/vor_vertices.c
+Vor_vertices:  $(SRC)/vor_vertices.c $(LIBS)
 	$(COMP) -o Vor_vertices \
         $(SRC)/vor_vertices.c  $(LIB)
 
-Vectoform:  $(SRC)/vectoform.c
+Vectoform:  $(SRC)/vectoform.c $(LIBS)
 	$(COMP) -o Vectoform \
         $(SRC)/vectoform.c  $(LIB)
 
-ZZprog:  $(SRC)/ZZprog.c
+ZZprog:  $(SRC)/ZZprog.c $(LIBS)
 	$(COMP) -o ZZprog \
         $(SRC)/ZZprog.c  $(LIB)
 	rm -f Sublattices
 	ln -f -s ZZprog Sublattices
 
-Zass_main:  $(SRC)/zass_main.c
+Zass_main:  $(SRC)/zass_main.c $(LIBS)
 	$(COMP) -o Zass_main \
         $(SRC)/zass_main.c  $(LIB)
 
-Z_equiv:  $(SRC)/z_equiv.c
+Z_equiv:  $(SRC)/z_equiv.c $(LIBS)
 	$(COMP) -o Z_equiv \
         $(SRC)/z_equiv.c  $(LIB)
 
-test:  $(SRC)/test.c
+test:  $(SRC)/test.c $(LIBS)
 	$(COMP) -o test \
         $(SRC)/test.c  $(LIB)
 
-minset:  $(SRC)/minset.c
+minset:  $(SRC)/minset.c $(LIBS)
 	$(COMP) -o minset \
         $(SRC)/minset.c  $(LIB)
 
-min_in:  $(SRC)/min_in.c
+min_in:  $(SRC)/min_in.c $(LIBS)
 	$(COMP) -o min_in \
         $(SRC)/min_in.c  $(LIB)
 
 clean:
-	rm -f Add
-	rm -f Aut_grp
-	rm -f Bravais_flok
-	rm -f Bravais_catalog
-	rm -f Bravais_inclusions
-	rm -f Con
-	rm -f Conv
-	rm -f Datei
-	rm -f Dsylv
-	rm -f Elt
-	rm -f First_perfect
-	rm -f Form_elt
-	rm -f Form_space
-	rm -f Formtovec
-	rm -f Full
-	rm -f Fundamental_domain
-	rm -f Gauss
-	rm -f Graph
-	rm -f Gittstab
-	rm -f Hypisom
-	rm -f Hypstab
-	rm -f Idem
-	rm -f Inv
-	rm -f Invar_space
-	rm -f Isometry
-	rm -f Is_finite
-	rm -f Conj_bravais
-	rm -f KSubgroups
-	rm -f KSupergroups
-	rm -f Kron
-	rm -f Long_solve
-	rm -f Ltm
-	rm -f Malloc_liste
-	rm -f Mink_red
-	rm -f Modp
-	rm -f Mtl
-	rm -f Mul
-	rm -f Normalizer
-	rm -f Normalizer_in_N
-	rm -f Normlin
-	rm -f Orbit
-	rm -f Orbit_representatives
-	rm -f Orbrep
-	rm -f Order
-	rm -f P_lse_solve
-	rm -f Pair_red
-	rm -f Pdet
-	rm -f Perfect_neighbours
-	rm -f Polyeder
-	rm -f Poincare
-	rm -f Rein
-	rm -f Reverse_name
-	rm -f Rest_short
-	rm -f Rform
-	rm -f Same_generators
-	rm -f Scalarmul
-	rm -f Scpr
-	rm -f Short
-	rm -f Short_reduce
-	rm -f Shortest
-	rm -f Signature
-	rm -f Simplify_mat
-	rm -f Solve
-	rm -f Symbol ; rm -f Bravais_type
-	rm -f TSubgroups
-	rm -f TSupergroups
-	rm -f Torsionfree
-	rm -f Tr
-	rm -f Tr_bravais
-	rm -f Trace
-	rm -f Trbifo
-	rm -f Vor_vertices
-	rm -f ZZprog ; rm -f Sublattices
-	rm -f Zass
-	rm -f Zass_main
-	rm -f Bravais_flok
-	rm -f Extensions ; rm -f Vector_systems
-	rm -f Extract ; rm -f Standard_affine_form
-	rm -f Name
-	rm -f Minpol
-	rm -f Red_gen
-	rm -f Conjugated
-	rm -f Order
-	rm -f Malloc_liste
-	rm -f Presentation
-	rm -f Q_catalog
-	rm -f QtoZ
-	rm -f Z_equiv
-	rm -f Bravais_equiv
-	rm -f Bravais_grp
-	rm -f Vectoform
-	rm -f Malloc_liste
-	rm -f core
+	rm -f */Add
+	rm -f */Aut_grp
+	rm -f */Bravais_flok
+	rm -f */Bravais_catalog
+	rm -f */Bravais_inclusions
+	rm -f */Con
+	rm -f */Conv
+	rm -f */Datei
+	rm -f */Dsylv
+	rm -f */Elt
+	rm -f */First_perfect
+	rm -f */Form_elt
+	rm -f */Form_space
+	rm -f */Formtovec
+	rm -f */Full
+	rm -f */Fundamental_domain
+	rm -f */Gauss
+	rm -f */Graph
+	rm -f */Gittstab
+	rm -f */Hypisom
+	rm -f */Hypstab
+	rm -f */Idem
+	rm -f */Inv
+	rm -f */Invar_space
+	rm -f */Isometry
+	rm -f */Is_finite
+	rm -f */Conj_bravais
+	rm -f */KSubgroups
+	rm -f */KSupergroups
+	rm -f */Kron
+	rm -f */Long_solve
+	rm -f */Ltm
+	rm -f */Malloc_liste
+	rm -f */Mink_red
+	rm -f */Modp
+	rm -f */Mtl
+	rm -f */Mul
+	rm -f */Normalizer
+	rm -f */Normalizer_in_N
+	rm -f */Normlin
+	rm -f */Orbit
+	rm -f */Orbit_representatives
+	rm -f */Orbrep
+	rm -f */Order
+	rm -f */P_lse_solve
+	rm -f */Pair_red
+	rm -f */Pdet
+	rm -f */Perfect_neighbours
+	rm -f */Polyeder
+	rm -f */Poincare
+	rm -f */Rein
+	rm -f */Reverse_name
+	rm -f */Rest_short
+	rm -f */Rform
+	rm -f */Same_generators
+	rm -f */Scalarmul
+	rm -f */Scpr
+	rm -f */Short
+	rm -f */Short_reduce
+	rm -f */Shortest
+	rm -f */Signature
+	rm -f */Simplify_mat
+	rm -f */Solve
+	rm -f */Symbol ; rm -f */Bravais_type
+	rm -f */TSubgroups
+	rm -f */TSupergroups
+	rm -f */Torsionfree
+	rm -f */Tr
+	rm -f */Tr_bravais
+	rm -f */Trace
+	rm -f */Trbifo
+	rm -f */Vor_vertices
+	rm -f */ZZprog ; rm -f */Sublattices
+	rm -f */Zass
+	rm -f */Zass_main
+	rm -f */Bravais_flok
+	rm -f */Extensions ; rm -f */Vector_systems
+	rm -f */Extract ; rm -f */Standard_affine_form
+	rm -f */Name
+	rm -f */Minpol
+	rm -f */Red_gen
+	rm -f */Conjugated
+	rm -f */Order
+	rm -f */Malloc_liste
+	rm -f */Presentation
+	rm -f */Q_catalog
+	rm -f */QtoZ
+	rm -f */Z_equiv
+	rm -f */Bravais_equiv
+	rm -f */Bravais_grp
+	rm -f */Vectoform
+	rm -f */Malloc_liste
+	rm -f */core
 
 strip:
 	strip *

--- a/functions/Datei/Makefile
+++ b/functions/Datei/Makefile
@@ -7,11 +7,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rDc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) $(OBJFLAGS) $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) $(OBJFLAGS) -I$(INCL)
 
 OBJS = brav_from_datei.o\
        free_bravais.o\
@@ -23,13 +19,17 @@ OBJS = brav_from_datei.o\
        lattice_tools.o\
        read_symbol.o\
        right_order.o\
-       super_lattice.o
-
-.c.o:
-	$(COMP) $< -o $@
+       super_lattice.o\
+       get_data_dir.o
 
 ALL:  $(OBJS)
 	$(AR) *.o
+
+get_data_dir.o:  get_data_dir.c
+	$(COMP) -DTOPDIR=\"$(TOPDIR)\" $<
+
+%.o: %.c
+	$(COMP) $< -o $@
 
 clean:
 	rm -f *.o

--- a/functions/Datei/get_data_dir.c
+++ b/functions/Datei/get_data_dir.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+void get_data_dir(char *result, const char *str) {
+  char *dir;
+  dir = getenv("CARAT_DIR");
+  if (dir)
+    sprintf(result, "%s/%s", dir, str);
+  else
+    sprintf(result, "%s/%s", TOPDIR, str);
+}

--- a/functions/Datei/get_symbol.c
+++ b/functions/Datei/get_symbol.c
@@ -4,6 +4,7 @@
 #include "matrix.h"
 #include "getput.h"
 #include "longtools.h"
+#include "datei.h"
 
 /************************************************************************** \
 @---------------------------------------------------------------------------
@@ -193,8 +194,8 @@ else
 	/*------------------------------------------------------------*\
 	| read file-reference                                             |
 	\*------------------------------------------------------------*/
-sy->fn = (char *) malloc(80 *sizeof(char));
-fn = (char *) malloc(80 *sizeof(char));
+sy->fn = (char *) malloc(1024 *sizeof(char));
+fn = (char *) malloc(1024 *sizeof(char));
 c=fscanf (infile, "%[ \t\n]", fn);
 c=fscanf (infile, "%[^\n]", fn);
 while(fn != NULL && fn[0] == ' ')
@@ -216,10 +217,7 @@ if(fn != NULL)
   strtok (fn, "%");
 if(fn != NULL)
 {
-  strcpy(sy->fn, TABLES);
-/************
-  strcpy(sy->fn, TOPDIR "/lib/");
-***********/
+  get_data_dir(sy->fn, "tables/");
   strcat(sy->fn, fn);
 }
 else{

--- a/functions/Datei/get_zentr.c
+++ b/functions/Datei/get_zentr.c
@@ -73,7 +73,7 @@ for ( k = 0; k < anz; k++) {
 	/*------------------------------------------------------------*\
 	| read  file with other almost decomposable bravais-group      |
 	\*------------------------------------------------------------*/
-old_fn = fn = (char *) malloc(80 *sizeof(char));
+old_fn = fn = (char *) malloc(1024 *sizeof(char));
 c=fscanf (infile, "%[ \t\n]", fn);
 c=fscanf (infile, "%[^\n]", fn);
 while(fn != NULL && fn[0] == ' ')
@@ -96,11 +96,8 @@ if(fn != NULL)
   strtok (fn, "%");
 if(fn != NULL)
 {                               
-  B->fn = calloc( 80 , sizeof(char) );
-  strcat( B->fn, TABLES);
-/***********************
-  strcat( B->fn, TOPDIR "/lib/");
-***********************/
+  B->fn = calloc( 1024, sizeof(char) );
+  get_data_dir(B->fn, "tables/");
   strcat(B->fn, fn);
   free ( fn );
 }

--- a/functions/Datei/lattice.c
+++ b/functions/Datei/lattice.c
@@ -13,11 +13,11 @@ lattice_element **lattice(char *symb,int dim,int almost,int zclass,int *no,
    int i, c;
 
    /* saves space on the stack */
-   static char filename[1000];
+   static char filename[1024], format[1024];
 
    /* get the appropiate filename */
-   sprintf(filename,"%s%s%d/%s%s_%d_%d",TOPDIR,"/tables/lattices/dim",
-             dim,"lattice_",symb,almost,zclass);
+   get_data_dir(format, "tables/lattices/dim%d/%s%s_%d_%d");
+   sprintf(filename, format, dim, "lattice_", symb, almost, zclass);
 
    infile = fopen(filename,"r");
 

--- a/functions/Datei/read_symbol.c
+++ b/functions/Datei/read_symbol.c
@@ -41,10 +41,9 @@ char *file_name;
 {
 char  string[80],
       slash, *str ;
-char f[80];
+char f[1024], dat[1024];
 /* changed from "static char fn[80]" to switch away from static variables */
 char *fn;
-char *dat;
 FILE *infile;
 int i, j, k, l, m, n, p, q, x, groesser;
 int no, c;
@@ -67,7 +66,7 @@ matrix_TYP *In;
 for (i=0;i<80;i++) string[i] = 0;
 
 /* inserted to switch away from static variables */
-fn = (char *) calloc(80,sizeof(char));
+fn = (char *) calloc(1024,sizeof(char));
 
 /*------------------------------------------------------------*\
 | Open input file               	         	       |
@@ -226,11 +225,7 @@ for(i=0; i<MAXDIM; i++)
 |  read the atoms                                                      |
 \*--------------------------------------------------------------------*/
 grps = (bravais_TYP **) malloc(konstit *sizeof(bravais_TYP *));
-dat = ATOMS;
-/**************
-dat = TOPDIR "/lib/atoms/";
-f = (char **) malloc(konstit *sizeof(char *));
-***************/
+get_data_dir(dat, "tables/atoms/");
 for(i=0; i<konstit; i++)
 {
    strcpy(f, dat);
@@ -503,10 +498,7 @@ for(i=0; i<konstit; i++)
 /*--------------------------------------------------------------------*\
 | find file where erg->grp->zentr are stored                           |
 \*--------------------------------------------------------------------*/
-strcpy(fn, TABLEDIM);
-/*********************************
-strcpy(fn, TOPDIR "/lib/dim");
-*********************************/
+get_data_dir(fn, "tables/dim");
 itoasc(erg->grp->dim, merk);
 strcat(fn, merk);
 strcat(fn, "/");

--- a/functions/Datei/super_lattice.c
+++ b/functions/Datei/super_lattice.c
@@ -15,11 +15,11 @@ lattice_element **super_lattice(char *symb,int dim,int almost,int zclass,
                     *TMP;
 
    /* saves space on the stack */
-   static char filename[1000];
+   static char filename[1024], format[1024];
 
    /* get the appropiate filename */
-   sprintf(filename,"%s%s%d/%s%s_%d_%d",TOPDIR,"/tables/lattices/dim",
-             dim,"reverse_",symb,almost,zclass);
+   get_data_dir(format, "tables/lattices/dim%d/%s%s_%d_%d");
+   sprintf(filename, format, dim, "reverse_", symb, almost, zclass);
 
    infile = fopen(filename,"r");
 
@@ -47,8 +47,8 @@ lattice_element **super_lattice(char *symb,int dim,int almost,int zclass,
 
          found = FALSE;
          /* get the appropiate filename */
-         sprintf(filename,"%s%s%d/%s%s_%d_%d",TOPDIR,"/tables/lattices/dim",
-                   dim,"lattice_",RES[i]->symbol,RES[i]->almost,RES[i]->zclass);
+         sprintf(filename, format, dim, "lattice_",
+		 RES[i]->symbol, RES[i]->almost, RES[i]->zclass);
 
          infile = fopen(filename,"r");
          c=fscanf(infile,"#%d\n",&pos);

--- a/functions/Idem/Makefile
+++ b/functions/Idem/Makefile
@@ -6,11 +6,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rDc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\" -DTABLES=\"$(TOPDIR)/tables/\" \
-         -DATOMS=\"$(TOPDIR)/tables/atoms/\" \
-         -DTABLEDIM=\"$(TOPDIR)/tables/dim\"
-
-COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 
 OBJS = almost_decomposable_lattice.o\
        bravais_catalog.o\

--- a/functions/Idem/bravais_catalog.c
+++ b/functions/Idem/bravais_catalog.c
@@ -24,9 +24,8 @@ char *symb;
 {
 char  string[80],
       slash, *str ;
-char f[80];
+char f[1024], dat[1024];
 char *fn;
-char *dat;
 int     i, j, k, l, m, n, p, q, x, groesser;
 int len;
 int no;
@@ -43,9 +42,8 @@ int zerleg[MAXDIM][5];
 bravais_TYP **grps;
 symbol_out *erg;
 matrix_TYP *In;
-
+ 
 fn = (char *) malloc(1024 * sizeof(char));
-
 for (i=0;i<80;i++) string[i] = 0;
 
 for( i=0; i<MAXDIM; i++)
@@ -185,11 +183,7 @@ for(i=0; i<MAXDIM; i++)
 |  read the atoms                                                      |
 \*--------------------------------------------------------------------*/
 grps = (bravais_TYP **) malloc(konstit *sizeof(bravais_TYP *));
-dat = ATOMS;
-/**************
-dat = TOPDIR "/lib/atoms/";
-f = (char **) malloc(konstit *sizeof(char *));
-***************/
+get_data_dir(dat, "tables/atoms/");
 for(i=0; i<konstit; i++)
 {
    strcpy(f, dat);
@@ -468,10 +462,7 @@ for(i=0; i<konstit; i++)
 /*--------------------------------------------------------------------*\
 | find file where erg->grp->zentr are stored                           |
 \*--------------------------------------------------------------------*/
-strcpy(fn, TABLEDIM);
-/*********************************
-strcpy(fn, TOPDIR "/lib/dim");
-*********************************/
+get_data_dir(fn, "tables/dim");
 itoasc(erg->grp->dim, merk);
 strcat(fn, merk);
 strcat(fn, "/");

--- a/functions/Idem/symbol.c
+++ b/functions/Idem/symbol.c
@@ -150,7 +150,7 @@ static char *identify_hom(bravais_TYP *G,int clear)
    char *result,
          tmp[20],
         *pp,
-         bravais_file[1000];
+         bravais_file[1024], format[1024];
 
    static symbol_out *Atoms;
 
@@ -164,11 +164,12 @@ static char *identify_hom(bravais_TYP *G,int clear)
 
    if (atom_no == 0){
        /* read the file with all atoms */
-       sprintf(bravais_file,"%s%s",TOPDIR,"/tables/symbol/atom_list");
+       get_data_dir(bravais_file, "tables/symbol/atom_list");
        atom_file = fopen(bravais_file,"r");
 
        if (atom_file == NULL){
-          fprintf(stderr,"I didn't find my library file. exiting.\n");
+	 fprintf(stderr, "I didn't find my library file %s. Exiting.\n",
+		 bravais_file);
           exit(4);
        }
 
@@ -183,8 +184,9 @@ static char *identify_hom(bravais_TYP *G,int clear)
        fclose(atom_file);
 
        /* and their respective groups */
+       get_data_dir(format, "tables/symbol/%s");
        for (i=0;i<atom_no;i++){
-          sprintf(bravais_file,"%s/tables/symbol/%s",TOPDIR,Atoms[i].fn);
+          sprintf(bravais_file, format, Atoms[i].fn);
           Atoms[i].grp = get_bravais(bravais_file);
           long_rein_formspace(G->form,G->form_no,1);
        }

--- a/functions/Name/HM_symbol.c
+++ b/functions/Name/HM_symbol.c
@@ -8,7 +8,6 @@
 #include "sort.h"
 #include "datei.h"
 
-#define HM_TABLE TOPDIR "/tables/qcatalog/translation_HM_symbol"
 
 
 static void remove_underscore(char *s)
@@ -47,14 +46,16 @@ void display_HM_symbol(char *qname,
    char qin[1028],
         affin[128],
         affstring[128],
-        HMSYMBOL[128];
+        HMSYMBOL[128],
+        hmtab[1024];;
 
    mpz_get_str(affstring,10,aff_name);
 
-   F = fopen(HM_TABLE,"r");
+   get_data_dir(hmtab, "tables/qcatalog/translation_HM_symbol");
+   F = fopen(hmtab, "r");
 
    if (F == NULL){
-      fprintf(stderr,"can't open %s\n",HM_TABLE);
+      fprintf(stderr,"can't open %s\n", hmtab);
       exit(4);
    }
 

--- a/functions/Name/Makefile
+++ b/functions/Name/Makefile
@@ -6,9 +6,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rDc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\"
-
-COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 
 OBJS = HM_symbol.o\
        Q_catalog.o\

--- a/functions/Name/aff_class_inf.c
+++ b/functions/Name/aff_class_inf.c
@@ -13,7 +13,6 @@
 #include "zass.h"
 #include "longtools.h"
 
-#define DATABASE_NAME TOPDIR "/tables/qcatalog/data"
 
 
 void extend(matrix_TYP *T)

--- a/functions/Name/q_class_inf.c
+++ b/functions/Name/q_class_inf.c
@@ -36,7 +36,7 @@ matrix_TYP *q_class_inf (bravais_TYP *G,
               *MATG,
               *ERG = NULL;  
 
-  char filetmp[1024];
+  char filetmp[1024], format[1024];
 
   int i,
       orderG = 0,
@@ -51,14 +51,15 @@ matrix_TYP *q_class_inf (bravais_TYP *G,
   G->order = orderG;
   factorize_new(G->order,G->divisors);
 
+  get_data_dir(format, "tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/char.%s");
   for (i=0;i<database->nr;i++){
       if (orderG == database->entry[i].order &&
           G->dim == database->entry[i].degree && 
           MATG->rows == database->entry[i].no_idem + 9 &&
           MATG->cols == database->entry[i].no_conclass ){
 
-          sprintf(filetmp,"%s/tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/char.%s",
-                          TOPDIR,G->dim,database->entry[i].symbol,
+          sprintf(filetmp, format,
+                          G->dim,database->entry[i].symbol,
                           orderG,database->entry[i].discriminant,
                           database->entry[i].abbreviation);
 
@@ -75,10 +76,11 @@ matrix_TYP *q_class_inf (bravais_TYP *G,
 
   /* there are 5 pairs of groups where the characteristic matrix does
      not decide the Q-equivalence. In these cases, get the hands dirty */
+  get_data_dir(format, "tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/%s");
   while (no_possible > 1) {
      i = possible[no_possible-1];
-     sprintf(filetmp,"%s/tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/%s",
-                     TOPDIR,G->dim,database->entry[i].symbol,
+     sprintf(filetmp, format,
+                     G->dim,database->entry[i].symbol,
                      orderG,database->entry[i].discriminant,
                      database->entry[i].abbreviation);
 
@@ -112,10 +114,11 @@ matrix_TYP *q_class_inf (bravais_TYP *G,
     exit(4);
   }
 
+  get_data_dir(format, "tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/%s"); 
   if (OUT || (transformation && !ERG) ){
      i = possible[0];
-     sprintf(filetmp,"%s/tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/%s",
-                     TOPDIR,G->dim,database->entry[i].symbol,
+     sprintf(filetmp, format,
+                     G->dim,database->entry[i].symbol,
                      orderG,database->entry[i].discriminant,
                      database->entry[i].abbreviation);
 
@@ -127,10 +130,11 @@ matrix_TYP *q_class_inf (bravais_TYP *G,
 
   }
 
+  get_data_dir(format, "tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/pres.%s"); 
   if (PRES){
     i = possible[0];
-     sprintf(filetmp,"%s/tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/pres.%s",
-                     TOPDIR,G->dim,database->entry[i].symbol,
+     sprintf(filetmp, format,
+                     G->dim,database->entry[i].symbol,
                      orderG,database->entry[i].discriminant,
                      database->entry[i].abbreviation);
 

--- a/functions/Name/reverse_name_fct.c
+++ b/functions/Name/reverse_name_fct.c
@@ -13,9 +13,6 @@
 #include "gmp.h"
 #include "longtools.h"
 
-#define DATABASE_NAME TOPDIR "/tables/qcatalog/data"
-
-
 
 bravais_TYP *get_qclass_by_name(char *name,
                                 matrix_TYP **PRES,
@@ -27,12 +24,15 @@ bravais_TYP *get_qclass_by_name(char *name,
 
    database *database;
 
-   char filename[1024];
+   char filename[1024], dbname[1024], format1[1024], format2[1024];
 
    bravais_TYP *G;
 
+   get_data_dir(dbname,  "tables/qcatalog/data");
+   get_data_dir(format1, "tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/%s");
+   get_data_dir(format2, "tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/pres.%s");
    while (!found){
-      database = load_database (DATABASE_NAME,dim);
+      database = load_database (dbname, dim);
 
       i = 0;
       while (!found && i<database->nr ){
@@ -43,14 +43,14 @@ bravais_TYP *get_qclass_by_name(char *name,
       if (found){
          i--;
 
-         sprintf(filename,"%s/tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/%s",
-                          TOPDIR,dim,database->entry[i].symbol,
+         sprintf(filename, format1,
+                          dim,database->entry[i].symbol,
                           database->entry[i].order,
                           database->entry[i].discriminant,name);
          G = get_bravais(filename);
 
-         sprintf(filename,"%s/tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/pres.%s",
-                          TOPDIR,dim,database->entry[i].symbol,
+         sprintf(filename, format2,
+                          dim,database->entry[i].symbol,
                           database->entry[i].order,
                           database->entry[i].discriminant,name);
          *PRES = get_mat(filename);

--- a/functions/TSubgroups/Makefile
+++ b/functions/TSubgroups/Makefile
@@ -6,9 +6,7 @@ INCL = $(TOPDIR)/include
 
 AR = ar rDc $(TOPDIR)/lib/functions.a
 
-GLOBAL = -DTOPDIR=\"$(TOPDIR)\"
-
-COMP = $(CC) $(CFLAGS) -c $(GLOBAL) -I$(INCL)
+COMP = $(CC) $(CFLAGS) -c -I$(INCL)
 
 OBJS = PoaN.o\
 	name_fct.o\

--- a/functions/TSubgroups/name_fct.c
+++ b/functions/TSubgroups/name_fct.c
@@ -17,10 +17,6 @@
 #include "longtools.h"
 #include "tsubgroups.h"
 
-#define DATABASE_NAME TOPDIR "/tables/qcatalog/data"
-
-
-
 
 /* ------------------------------------------------------------------- */
 /* Berechne den Namen einer Raumgruppe R in CARAT-Notation und gebe    */

--- a/functions/TSubgroups/tSUPERgroups_fct_db.c
+++ b/functions/TSubgroups/tSUPERgroups_fct_db.c
@@ -8,9 +8,6 @@
 #include <name.h>
 #include <datei.h>
 
-#define DATABASE_NAME TOPDIR "/tables/qcatalog/data"
-
-
 
 /* ---------------------------------------------------------------------- */
 /* Berechne diejenigen t-Obergruppen einer Raumgruppe, die in einer       */
@@ -202,7 +199,7 @@ bravais_TYP **tsupergroups(bravais_TYP *R,
 
    database *database;
 
-   char pfad[1024];
+   char pfad[1024], dbname[1024], format[1024];
 
    int i, j, no, dim;
 
@@ -213,17 +210,19 @@ bravais_TYP **tsupergroups(bravais_TYP *R,
 
    /* lade Datenbank */
    dim = R->dim - 1;
-   database = load_database(DATABASE_NAME, dim);
+   get_data_dir(dbname, "/tables/qcatalog/data");
+   database = load_database(dbname, dim);
 
    /* berechne den Namen */
    Name = name_fct(R, database);
    inv = mat_inv(Name.trafo);
 
+   get_data_dir(format, "tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/");
    for (i = 0; i < database->nr; i++){
       if (database->entry[i].order > Name.order &&
           database->entry[i].order % Name.order == 0){
-         sprintf(pfad,"%s/tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/",
-                 TOPDIR, dim, database->entry[i].symbol,
+	  sprintf(pfad, format,
+                 dim, database->entry[i].symbol,
                  database->entry[i].order, database->entry[i].discriminant);
 
          tmp = get_supergr(pfad, database->entry[i].abbreviation, Name,

--- a/functions/TSubgroups/tsubgroups_fct.c
+++ b/functions/TSubgroups/tsubgroups_fct.c
@@ -7,10 +7,6 @@
 #include <datei.h>
 #include <graph.h>
 
-#define DATABASE_NAME TOPDIR "/tables/qcatalog/data"
-
-
-
 
 /* -------------------------------------------------------------------- */
 /* transform the i-th row of a matrix to a list of integers             */
@@ -123,13 +119,14 @@ TSubgroup_TYP **tsubgroup(bravais_TYP *R,
 
    database *database;
 
-
+   char dbname[1024];
 
    if (cflag)
       aflag = TRUE;
       
    /* lade Datenbank */
-   database = load_database(DATABASE_NAME, P->dim);
+   get_data_dir(dbname, "/tables/qcatalog/data");
+   database = load_database(dbname, P->dim);
 
 
 

--- a/functions/TSubgroups/tsubgroups_fct_db.c
+++ b/functions/TSubgroups/tsubgroups_fct_db.c
@@ -7,10 +7,6 @@
 #include <name.h>
 #include <datei.h>
 
-#define DATABASE_NAME TOPDIR "/tables/qcatalog/data"
-
-
-
 
 /* ---------------------------------------------------------------------- */
 /* Berechne die maximalen t-Untergruppen einer Raumgruppe                 */
@@ -36,7 +32,7 @@ TSubgroup_TYP **tsubgroup_db(bravais_TYP *R,
 
    database *database;
 
-   char pfad[1024];
+   char pfad[1024], dbname[1024], format[1024];
 
    int i, k, dim, found = 0, j;
 
@@ -44,7 +40,8 @@ TSubgroup_TYP **tsubgroup_db(bravais_TYP *R,
 
    /* berechne den Namen */
    dim = R->dim - 1;
-   database = load_database(DATABASE_NAME, dim);
+   get_data_dir(dbname, "/tables/qcatalog/data");
+   database = load_database(dbname, dim);
    Name = name_fct(R, database);
 
 
@@ -56,10 +53,11 @@ TSubgroup_TYP **tsubgroup_db(bravais_TYP *R,
       i++;
    }
 
+   get_data_dir(format, "tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/");
    if (found){
       i--;
-      sprintf(pfad,"%s/tables/qcatalog/dim%d/dir.%s/ordnung.%d/%s/",
-              TOPDIR, dim, database->entry[i].symbol,
+      sprintf(pfad, format,
+              dim, database->entry[i].symbol,
               database->entry[i].order, database->entry[i].discriminant);
 
       Rstd = get_std_rep(pfad, Name);

--- a/include/datei.h
+++ b/include/datei.h
@@ -87,6 +87,12 @@ lattice_element **lattice(char *symb,int dim,int almost,int zclass,int *no,
 lattice_element **super_lattice(char *symb,int dim,int almost,int zclass,
 		int *no, int OPTION);
 
+/*------------------------------------------------------------*\
+| FILE: get_data_dir.c
+\*------------------------------------------------------------*/
+
+void get_data_dir(char *result, const char *str);
+
 #else
 
 /*-------------------------------------------------------------*\
@@ -146,6 +152,12 @@ void fput_lattice_element();
 
 lattice_element **lattice(char *symb,int dim,int almost,int zclass,int *no,
                           int OPTION);
+
+/*------------------------------------------------------------*\
+| FILE: get_data_dir.c
+\*------------------------------------------------------------*/
+
+void get_data_dir();
 
 #endif
 #endif

--- a/src/Q_catalog.c
+++ b/src/Q_catalog.c
@@ -7,13 +7,12 @@
 #include "matrix.h"
 #include "datei.h"
 
-#define DATABASE_NAME TOPDIR "/tables/qcatalog/data"
 int SFLAG;
 int INFO_LEVEL;
 
 static void write_groups_to_file (int *write_list, database *database, char *string)
 {
-  char argument [80], inputfilename [300];
+  char argument [80], inputfilename [1024], format[1024];
   FILE *outputfile, *inputfile;
   int i, data_char;
   
@@ -39,12 +38,12 @@ static void write_groups_to_file (int *write_list, database *database, char *str
       fprintf (stdout, "Write to file: w <filename>\nWrite to stdout: w -s\n\n\n");
       return;
     }
-  
+
+  get_data_dir(format, "tables/qcatalog/dim%i/dir.%s/ordnung.%i/%s/%s");
   for (i=0; i<database->nr; i++)
     if (write_list[i] == ALL_MATCH)
       {
-	sprintf (inputfilename,
-		 TOPDIR "/tables/qcatalog/dim%i/dir.%s/ordnung.%i/%s/%s",
+	sprintf (inputfilename, format, 
 		 (database->entry [i]).degree,
 		 (database->entry [i]).symbol,
 		 (database->entry [i]).order,
@@ -364,8 +363,7 @@ int main (int argc, char *argv[])
 
   matrix_TYP *T;
 
-  char name[1024],
-       symb[1024];
+  char name[1024], symb[1024], dbname[1024];
 
   extern int FILEANZ;
   extern char **FILENAMES;
@@ -404,10 +402,11 @@ int main (int argc, char *argv[])
       exit (EXIT_SUCCESS);
     }
   
+  get_data_dir(dbname, "tables/qcatalog/data");
   if (FILEANZ == 1){
     G = get_bravais(FILENAMES[0]);
 
-    database = load_database (DATABASE_NAME,G->dim);
+    database = load_database (dbname, G->dim);
   
     display_list = (int *) malloc (database->nr * sizeof (int));
 
@@ -437,7 +436,7 @@ int main (int argc, char *argv[])
 
   }
   else if (FILEANZ == 0){
-    database = load_database (DATABASE_NAME,0);
+    database = load_database (dbname, 0);
     
     display_list = (int *) malloc (database->nr * sizeof (int));
     

--- a/src/name.c
+++ b/src/name.c
@@ -14,8 +14,6 @@
 #include "gmp.h"
 #include "longtools.h"
 
-#define DATABASE_NAME TOPDIR "/tables/qcatalog/data"
-
 boolean GRAPH = FALSE;
 int SFLAG;
 int INFO_LEVEL;
@@ -47,7 +45,7 @@ int main (int argc, char *argv[])
 
   int zname[2];
 
-  char comment[1024];
+  char comment[1024], dbname[1024];
 
   read_header (argc, argv);
 
@@ -107,7 +105,8 @@ int main (int argc, char *argv[])
      P = point_group(R,2);
   }
 
-  database = load_database (DATABASE_NAME,P->dim);
+  get_data_dir(dbname, "tables/qcatalog/data");
+  database = load_database (dbname, P->dim);
 
   T = q_class_inf (P,database,qname,symb,&DATAQ,&PRES,FALSE);
 

--- a/src/reverse_name.c
+++ b/src/reverse_name.c
@@ -13,8 +13,6 @@
 #include "gmp.h"
 #include "longtools.h"
 
-#define DATABASE_NAME TOPDIR "/tables/qcatalog/data"
-
 int SFLAG;
 int INFO_LEVEL;
 boolean GRAPH = FALSE;


### PR DESCRIPTION
The lookup of the location of the CARAT data tables happens now in a
single function in functions/Datei/get_data_dir.c. It first looks at
the value of the environment variable CARAT_DIR, if it exists, and
takes the value of TOPDIR at compile time otherwise.