### PR TITLE
Fix crash in TSupergroups

### DIFF
--- a/functions/TSubgroups/tSUPERgroups_fct_db.c
+++ b/functions/TSubgroups/tSUPERgroups_fct_db.c
@@ -49,6 +49,7 @@ static bravais_TYP **get_supergr(char *pfad,
 
 
    /* Vorbereitungen */
+   memset(&NameSstd, 0, sizeof(NameSstd));
    anzahl[0] = 0;
    snprintf(filename, 1024, "%s/words.%s", pfad, qnameS);
    if ( (infile = fopen(filename, "r")) == NULL ) {


### PR DESCRIPTION
NameSstd was not initialized, in particular NameSstd.trafo was not.
But we call free_CARATname_TYP(NameSstd), which does this, with
Name = NameSstd:

    if (Name.trafo)
       free_mat(Name.trafo);

Now Name.trafo had a random value, usually not zero; trying to free
it then causes a crash.

Fixes #8