### PR TITLE
Fix potential crash in t_subgroups

### DIFF
--- a/functions/Graph/sub-t-groups-fcts.c
+++ b/functions/Graph/sub-t-groups-fcts.c
@@ -355,7 +355,7 @@ bravais_TYP ****t_subgroups(bravais_TYP *G,
    sub = t_sub_info(mats, no, G, G_geninv);
    WORDS = (int ***)calloc(MIN_SPEICHER, sizeof(int **));
    NUMBER_OF_WORDS = (int *)calloc(MIN_SPEICHER, sizeof(int));
-   coz = all_cocycles(pres, G, aff_no, G_geninv, &X, &names, WORDS, NUMBER_OF_WORDS,
+   coz = all_cocycles(pres, G, aff_no, G_geninv, &X, &names, &WORDS, &NUMBER_OF_WORDS,
                       &trash, &coho_size, &trashlist, 1);
    if (trash != NULL){
       for (i = 0; i < G->normal_no; i++)


### PR DESCRIPTION
However, this function is actually never called, so there was no
way to trigger this crash by using the standalone binaries.

An alternate fix would be to remove `functions/Graph/sub-t-groups-fcts.c`