### PR TITLE
Fix crash by removing useless code

### DIFF
--- a/functions/Graph/graph_tools.c
+++ b/functions/Graph/graph_tools.c
@@ -55,9 +55,6 @@ bravais_TYP *extract_r(bravais_TYP *G,
 
    int i, j;
 
-   char comment[1000];
-
-
    rat2kgv(X);
    Check_mat(X);
 
@@ -85,8 +82,6 @@ bravais_TYP *extract_r(bravais_TYP *G,
       H->gen[i]->array.SZ[H->dim-1][H->dim-1] = X->kgv;
       Check_mat(H->gen[i]);
    }
-   sprintf(comment,"space group to the point group of %s and cozycle %s",
-           FILENAMES[0],FILENAMES[1]);
   
    return(H);
 }


### PR DESCRIPTION
If FILENAMES[0] and/or FILENAMES[1] are too long, the removed sprintf
caused a buffer overflow, which caused crashes for me in the tests.
But the buffer is never used again afterwards, so just remove it.