### PR TITLE
tst/run_all.sh: use unified diff format

### DIFF
--- a/tst/run_all.sh
+++ b/tst/run_all.sh
@@ -17,7 +17,7 @@ for testfile in *.tst; do
     name="$(basename -s .tst ${testfile})"
     #bash -e "./${name}.tst" > "${name}.tmp" 2>&1
     bash "./${name}.tst" > "${name}.tmp" 2>&1
-    if ! diff -b "${name}.out" "${name}.tmp"; then
+    if ! diff -u -b "${name}.out" "${name}.tmp"; then
         echo "${testfile} failed, see observed/expected output above"
         retvalue=1
     else


### PR DESCRIPTION
I guess this is a matter of taste, but I really prefer the unified diffs; for some reason, they are much easier for my brain to interpret. So if nobody else minds, it would be nice to have that. Of course other people may have the reverse preference; in that case, just close this PR, it's not that important :-)