### PR TITLE
Travis: move build steps to before_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,11 @@ matrix:
           - libgmp-dev:i386
 
 # temporary hack with sed until we will have a proper configure script
-script:
+before_script:
   - ./autogen.sh && ./configure
   - make -j2 V=1
+
+script:
   - cd tst && ./run_all.sh
 
 after_script:


### PR DESCRIPTION
This way, a compilation error aborts Travis immediately
instead of running the test suite.
