### PR TITLE
#include guards now start with CARAT

### DIFF
--- a/functions/Autgrp/autgrp.c
+++ b/functions/Autgrp/autgrp.c
@@ -1,7 +1,7 @@
 /*****	Main program for the automorphism program AUTO	*****/
-#include "sort.h"
 #include "typedef.h"
 #include "types.h"
+#include "sort.h"
 
 /**************************************************************************\
 @---------------------------------------------------------------------------
@@ -12,13 +12,13 @@
 @
 \**************************************************************************/
 
-int     normal_option = 0;
-int     perp_no = 0;
-int *** perp = 0;
-int     perpdim = 0;
-int *** perpbase = 0;
-int *** perpprod = 0;
-int *   perpvec = 0;
+int normal_option = 0;
+int perp_no = 0;
+int ***perp = 0;
+int perpdim = 0;
+int ***perpbase = 0;
+int ***perpprod = 0;
+int *perpvec = 0;
 
 /*************************************************************************\
 @-------------------------------------------------------------------------
@@ -37,11 +37,10 @@ int *   perpvec = 0;
 @ matrix_TYP	**Erz:		if already element of G are known,
 @				they can be used for calculating generators
 @				for the whole group.
-@				The matrices of known elements can be given
+@				The matrices of known elements can be given 
 @				to the function by the pointer 'Erz'.
 @ int		Erzanz:		The number of matrices given in 'Erz"
-@ matrix_TYP	*SV:		The rows of the matrix 'SV' must be the
-vectors
+@ matrix_TYP	*SV:		The rows of the matrix 'SV' must be the vectors
 @				x in Z^n with x * F[0] * x^{tr} <= m, where
 @				m is the maximal diagonal entry of the Matrix
 @				F[0]
@@ -58,10 +57,10 @@ vectors
 @		will be calculated.
 @ options[2]:	If options[2] = 1, additional output is written to the
 @               file AUTO.tmp
-@ options[3]:   If options[3] = 1, Bacher polynomials are used.
+@ options[3]:   If options[3] = 1, Bacher polynomials are used. 
 @		If options[3] = 2, Bacher polynomial are used up to a deepth
 @		                   specified in options[4].
-@		If options[3] = 3, Bacher polynomials are used, using
+@		If options[3] = 3, Bacher polynomials are used, using 
 @		                   combinations of vectors having the scalar
 @		                   product specified in options[5]
 @		options[3] = 4 is the combination of options[3] = 2 and
@@ -75,477 +74,487 @@ vectors
 \*************************************************************************/
 
 
-bravais_TYP * autgrp(matrix_TYP ** Fo,
-                     int           Foanz,
-                     matrix_TYP *  SV,
-                     matrix_TYP ** Erz,
-                     int           Erzanz,
-                     int *         options)
+bravais_TYP *
+autgrp (matrix_TYP **Fo, int Foanz, matrix_TYP *SV, matrix_TYP **Erz, int Erzanz, int *options)
 {
-    FILE *        outfile;
-    bachpol *     bach = 0;
-    flagstruct    flags;
-    scpcomb *     comb = 0;
-    group         G;
-    invar         F;
-    veclist       V, norm;
-    fpstruct      fp;
-    int           dim, max, fail, *vec;
-    int ***       H = 0, nH = 0, ngen, **sumveclist, **sumvecbase;
-    int           i, j, k, l, n, *Vvi, *Vvj, **Fvi, *Fvij, **FAi;
-    bravais_TYP * B;
+	FILE		*outfile;
+	bachpol		*bach = 0;
+	flagstruct	flags;
+	scpcomb		*comb = 0;
+	group		G;
+	invar		F;
+	veclist		V, norm;
+	fpstruct	fp;
+	int		dim, max, fail, *vec;
+	int		***H = 0, nH = 0, ngen, **sumveclist, **sumvecbase;
+	int		i, j, k, l, n, *Vvi, *Vvj, **Fvi, *Fvij, **FAi;
+        bravais_TYP *B;
 
-    normal_option = FALSE;
-    /* get the flags from the command line */
-    getflags(&flags, options);
-    if (Erzanz > 0)
-        flags.GEN = 1;
-    else
-        flags.GEN = 0;
-    /* F.n is the number of invariant forms */
-    F.n = Foanz;
-    if ((F.A = (int ***)malloc(F.n * sizeof(int **))) == 0)
-        exit(2);
-    /* read the invariant forms */
-    F.dim = Fo[0]->cols;
-    dim = F.dim;
-    for (i = 0; i < F.n; i++) {
-        if (Fo[i]->cols != F.dim || Fo[i]->rows != F.dim) {
-            printf("forms in autgrp have different dimension\n");
-            exit(3);
+   normal_option = FALSE;
+/* get the flags from the command line */
+	getflags(&flags, options);
+   if(Erzanz > 0)
+     flags.GEN = 1;
+   else
+     flags.GEN = 0;
+/* F.n is the number of invariant forms */
+	F.n = Foanz;
+	if ((F.A = (int***)malloc(F.n * sizeof(int**))) == 0)
+		exit (2);
+/* read the invariant forms */
+        F.dim = Fo[0]->cols;
+	dim = F.dim;
+        for(i=0;i<F.n;i++)
+        {
+           if(Fo[i]->cols != F.dim || Fo[i]->rows != F.dim)
+           {
+              printf("forms in autgrp have different dimension\n");
+              exit(3);
+           }
         }
-    }
-    for (i = 0; i < F.n; i++) {
-        if ((F.A[i] = (int **)malloc(dim * sizeof(int *))) == 0)
-            exit(2);
-        for (j = 0; j < F.dim; j++) {
-            if ((F.A[i][j] = (int *)malloc(dim * sizeof(int))) == 0)
-                exit(2);
-            for (k = 0; k < F.dim; k++)
-                F.A[i][j][k] = Fo[i]->array.SZ[j][k];
+        for(i=0;i<F.n;i++)
+        {
+	  if ((F.A[i] = (int**)malloc(dim * sizeof(int*))) == 0)
+		exit (2);
+          for(j=0;j<F.dim;j++)
+          {
+	    if ((F.A[i][j] = (int*)malloc(dim * sizeof(int))) == 0)
+		  exit (2);
+            for(k=0;k<F.dim;k++)
+              F.A[i][j][k] = Fo[i]->array.SZ[j][k];
+          }
         }
-    }
-    if (flags.GEN == 1)
-    /* some automorphisms are already known */
-    {
-        ngen = Erzanz;
-        if ((H = (int ***)malloc(ngen * sizeof(int **))) == 0)
-            exit(2);
-        nH = 0;
-        fail = 0;
-        for (i = 0; i < ngen; i++) {
-            if (Erz[i]->cols != dim || Erz[i]->rows != dim) {
-                printf("Elements 'Erz' have wrong dimension\n");
-                exit(3);
-            }
-        }
-        i = 0;
-        while (nH + fail < ngen) {
-            if ((H[nH] = (int **)malloc(dim * sizeof(int *))) == 0)
-                exit(2);
-            for (j = 0; j < dim; j++) {
-                if ((H[nH][j] = (int *)malloc(dim * sizeof(int))) == 0)
-                    exit(2);
-                for (k = 0; k < dim; k++)
-                    H[nH][j][k] = Erz[i]->array.SZ[k][j];
-            }
-            /* check whether the matrix is really an automorphism, i.e. fixes
-             * the forms */
-            if (checkgen(H[nH], F) == 0)
-            /* the matrix is not an automorphism */
-            {
-                ++fail;
-                for (j = 0; j < dim; ++j)
-                    free(H[nH][j]);
-                free(H[nH]);
-            }
-            else
-                /* the matrix fixes all forms in F */
-                ++nH;
-            i++;
-        }
-    }
-    else
-        nH = 0;
-
-
-    V.dim = dim;
-    V.len = dim + F.n;
-    /* get the short vectors */
-    V.n = SV->rows;
-    if ((V.v = (int **)malloc((V.n + 1) * sizeof(int *))) == 0)
-        exit(2);
-    for (i = 0; i <= V.n; i++) {
-        if ((V.v[i] = (int *)malloc(V.len * sizeof(int))) == 0)
-            exit(2);
-    }
-    for (i = 1; i <= V.n; i++) {
-        for (j = 0; j <= dim; j++)
-            V.v[i][j] = SV->array.SZ[i - 1][j];
-    }
-    /* the first nonzero entry of each vector is made positive and the maximal
-       entry of the vectors is determined */
-    max = 1;
-    for (i = 1; i <= V.n; ++i) {
-        Vvi = V.v[i];
-        for (j = 0; j < dim && Vvi[j] == 0; ++j)
-            ;
-        if (j < dim && Vvi[j] < 0) {
-            for (k = j; k < dim; ++k)
-                Vvi[k] *= -1;
-        }
-        for (k = j; k < dim; ++k) {
-            if (abs(Vvi[k]) > max)
-                max = abs(Vvi[k]);
-        }
-    }
-    if (max > MAXENTRY)
-    /* there is an entry, which is bigger than MAXENTRY, which might cause
-       overflow, since the program doesn't use long integer arithmetic */
-    {
-        fprintf(stderr,
-                "Error: Found entry %d in short vectors.\nTo avoid overflow, "
-                "the entries should not exceed %d.\n",
-                max, MAXENTRY);
-        exit(3);
-    }
-    /* V.prime is a prime p, such that every entry x in the short vectors
-       remains
-       unchanged under reduction mod p in symmetric form, i.e. -p/2 < x <= p/2
-     */
-    for (V.prime = 2 * max + 1; isprime(V.prime) == 0; ++V.prime)
-        ;
-    /* sort the vectors and delete doublets */
-    sortvecs(&V);
-    /* the norm-vector (i.e. the vector of the norms with respect to the
-       different invariant forms) of each vector must be equal to the
-       norm-vector of one of the vectors from the standard-base */
-    if ((norm.v = (int **)malloc((dim + 1) * sizeof(int *))) == 0)
-        exit(2);
-    norm.n = dim;
-    norm.dim = F.n;
-    norm.len = F.n;
-    for (i = 1; i <= norm.n; ++i) {
-        /* norm.v[i] is the norm combination of the (i-1)-th base-vector */
-        if ((norm.v[i] = (int *)malloc(norm.dim * sizeof(int))) == 0)
-            exit(2);
-        for (k = 0; k < norm.dim; ++k)
-            norm.v[i][k] = F.A[k][i - 1][i - 1];
-    }
-    sortvecs(&norm);
-    /* delete those vectors, which can not be the image of any of the
-       standard-base vectors */
-    checkvecs(&V, F, norm);
-    for (i = 1; i <= norm.n; ++i)
-        free(norm.v[i]);
-    free(norm.v);
-    /* print the invariant forms, if output is in ASCII-format */
-    /*********************************************
-                    printf("#%d\n", F.n);
-                    for (i = 0; i < F.n; ++i)
-                            putform(F.A[i], dim);
-    **********************************************/
-    /* F.v[i][j] is the transposed of the product of the Gram-matrix F.A[i]
-       with the transposed of the vector v[j], hence the scalar product of
-       v[j] and v[k] with respect to the Gram-matrix F.A[i] can be computed as
-       standard scalar product of v[j] and F.v[i][k] */
-    if ((F.v = (int ***)malloc(F.n * sizeof(int **))) == 0)
-        exit(2);
-    /* the product of the maximal entry in the short vectors with the maximal
-       entry in F.v[i] should not exceed MAXNORM to avoid overflow */
-    max = MAXNORM / max;
-    for (i = 0; i < F.n; ++i) {
-        FAi = F.A[i];
-        if ((F.v[i] = (int **)malloc((V.n + 1) * sizeof(int *))) == 0)
-            exit(2);
-        Fvi = F.v[i];
-        for (j = 1; j <= V.n; ++j) {
-            Vvj = V.v[j];
-            if ((Fvi[j] = (int *)malloc(dim * sizeof(int))) == 0)
-                exit(2);
-            Fvij = Fvi[j];
-            for (k = 0; k < dim; ++k) {
-                Fvij[k] = sscp(FAi[k], Vvj, dim);
-                if (abs(Fvij[k]) > max)
-                /* some entry in F.v[i] is too large */
+	if (flags.GEN == 1)
+/* some automorphisms are already known */
+	{
+		ngen = Erzanz;
+		if ((H = (int***)malloc(ngen * sizeof(int**))) == 0)
+			exit (2);
+		nH = 0;
+		fail = 0;
+                for(i=0;i<ngen;i++)
                 {
-                    fprintf(stderr,
-                            "Error: Found entry %d in F.v.\nTo avoid "
-                            "overflow, the entries should not exceed %d.\n",
-                            Fvij[k], max);
+                  if(Erz[i]->cols != dim || Erz[i]->rows != dim)
+                  {
+                    printf("Elements 'Erz' have wrong dimension\n");
                     exit(3);
+                  }
                 }
-            }
-        }
-    }
-    /* fp.per is the order in which the images of the base-vectors are set */
-    if ((fp.per = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    /* fp.e[i] is the index in V.v of the i-th vector of the standard-base in
-       the new order */
-    if ((fp.e = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    /* fp.diag is the diagonal of the fingerprint in the new order, fp.diag[i]
-       is an upper bound for the length of the orbit of the i-th base-vector
-       under the stabilizer of the preceding ones */
-    if ((fp.diag = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    /* compute the fingerprint */
-    fingerprint(&fp, F, V);
-    if (flags.PRINT == 1)
-    /* if the -P option is given, print the diagonal fp.diag and the number of
-       short vectors on AUTO.tmp */
-    {
-        outfile = fopen("AUTO.tmp", "a");
-        fprintf(outfile, "%d short vectors\n", 2 * V.n);
-        fprintf(outfile, "fingerprint diagonal:\n");
-        for (i = 0; i < dim; ++i)
-            fprintf(outfile, " %2d", fp.diag[i]);
-        fprintf(outfile, "\n");
-        fclose(outfile);
-    }
-    /* get the standard basis in the new order */
-    if ((vec = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    for (i = 0; i < dim; ++i) {
-        for (j = 0; j < dim; ++j)
-            vec[j] = 0;
-        vec[fp.per[i]] = 1;
-        fp.e[i] = numberof(vec, V);
-        if (abs(fp.e[i]) > V.n)
-        /* the standard-base must occur in the set of short vectors, since Id
-           is certainly an automorphism */
-        {
-            fprintf(stderr, "Error: standard basis vector nr. %d not found\n",
-                    i);
-            exit(2);
-        }
-    }
-    free(vec);
-    /* if the -D option is given, the scalar product combinations and the
-       corresponding vector sums are computed for the standard-basis */
-    if (flags.DEPTH > 0) {
-        if ((comb = (scpcomb *)malloc(dim * sizeof(scpcomb))) == 0)
-            exit(2);
-        for (i = 0; i < dim; ++i) {
-            /* compute the list of scalar product combinations and the
-               corresponding vector sums */
-            scpvecs(&comb[i].list, &sumveclist, i, fp.e, flags.DEPTH, V, F);
-            /* compute a basis for the lattice that is generated by the vector
-               sums and a transformation matrix that expresses the basis in
-               terms of the vector sums */
-            base(&comb[i], &sumvecbase, sumveclist, F.A[0], dim);
-            if (flags.PRINT == 1)
-            /* if the -P option is given, print the rank of the lattice
-               generated by the vector sums on level i on AUTO.tmp */
-            {
-                outfile = fopen("AUTO.tmp", "a");
-                fprintf(outfile, "comb[%d].rank = %d\n", i, comb[i].rank);
-                fclose(outfile);
-            }
-            /* compute the coefficients of the vector sums in terms of the
-             * basis */
-            coef(&comb[i], sumvecbase, sumveclist, F.A[0], dim);
-            for (j = 0; j <= comb[i].list.n; ++j)
-                free(sumveclist[j]);
-            free(sumveclist);
-            /* compute the scalar products of the base-vectors */
-            scpforms(&comb[i], sumvecbase, F);
-            for (j = 0; j < comb[i].rank; ++j)
-                free(sumvecbase[j]);
-            free(sumvecbase);
-        }
-    }
-    /* the Bacher-polynomials for the first BACHDEP base-vectors are computed,
-       if no scalar product was given as an argument, the scalar product is
-       set
-       to 1/2 the norm of the base-vector (with respect to the first form) */
-    if (flags.BACH[0] == 1) {
-        if ((bach = (bachpol *)malloc(flags.BACHDEP * sizeof(bachpol))) == 0)
-            exit(2);
-        for (i = 0; i < flags.BACHDEP; ++i) {
-            if (flags.BACH[2] == 0)
-                /* no scalar product was given as an option */
-                flags.BACHSCP = V.v[fp.e[i]][dim] / 2;
-            /* compute the Bacher-polynomial */
-            bacher(&bach[i], fp.e[i], flags.BACHSCP, V, F.v[0]);
-            if (flags.PRINT == 1)
-            /* if the -P option is given, print the Bacher-polynomial on
-               AUTO.tmp */
-            {
-                outfile = fopen("AUTO.tmp", "a");
-                fprintf(outfile,
-                        "Bacher-polynomial of base vector fp.e[%d]:\n", i);
-                fputbach(outfile, bach[i]);
-                fclose(outfile);
-            }
-        }
-    }
-    /* set up the group: the generators in G.g[i] are matrices that fix the
-       first i base-vectors but do not fix fp.e[i] */
-    if ((G.g = (int ****)malloc(dim * sizeof(int ***))) == 0)
-        exit(2);
-    /* G.ng is the number of generators in G.g[i] */
-    if ((G.ng = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    /* the first G.nsg[i] generators in G.g[i] are obtained as stabilizer
-       elements and are not necessary to generate the group */
-    if ((G.nsg = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    /* G.ord[i] is the orbit length of fp.e[i] under the generators in
-       G.g[i] ... G.g[dim-1] */
-    if ((G.ord = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    for (i = 0; i < dim; ++i) {
-        if ((G.g[i] = (int ***)malloc(1 * sizeof(int **))) == 0)
-            exit(2);
-        G.ng[i] = 0;
-        G.nsg[i] = 0;
-    }
-    G.dim = dim;
-    if ((G.g[0][0] = (int **)malloc(dim * sizeof(int *))) == 0)
-        exit(2);
-    /* -Id is always an automorphism */
-    for (i = 0; i < dim; ++i) {
-        if ((G.g[0][0][i] = (int *)malloc(dim * sizeof(int))) == 0)
-            exit(2);
-        for (j = 0; j < dim; ++j)
-            G.g[0][0][i][j] = 0;
-        G.g[0][0][i][i] = -1;
-        G.ng[0] = 1;
-    }
-    /* fill in the generators which were given as input */
-    for (i = 0; i < nH; ++i) {
-        for (j = 0; j < dim && operate(fp.e[j], H[i], V) == fp.e[j]; ++j)
-            ;
-        if (j < dim)
-        /* the generator is not Id and fixes fp.e[0],...,fp.e[j-1] but not
-           fp.e[j] */
-        {
-            ++G.ng[j];
-            if ((G.g[j] =
-                     (int ***)realloc(G.g[j], G.ng[j] * sizeof(int **))) == 0)
-                exit(2);
-            if ((G.g[j][G.ng[j] - 1] = (int **)malloc(dim * sizeof(int *))) ==
-                0)
-                exit(2);
-            for (k = 0; k < dim; ++k) {
-                if ((G.g[j][G.ng[j] - 1][k] =
-                         (int *)malloc(dim * sizeof(int))) == 0)
-                    exit(2);
-                for (l = 0; l < dim; ++l)
-                    G.g[j][G.ng[j] - 1][k][l] = H[i][k][l];
-            }
-        }
-        for (k = 0; k < dim; ++k)
-            free(H[i][k]);
-        free(H[i]);
-    }
-    if (nH > 0)
-        free(H);
-    nH = 0;
-    for (i = 0; i < dim; ++i)
-        nH += G.ng[i];
-    if ((H = (int ***)malloc(nH * sizeof(int **))) == 0)
-        exit(2);
-    /* calculate the orbit lengths under the automorphisms known so far */
-    for (i = 0; i < dim; ++i) {
-        if (G.ng[i] > 0) {
-            nH = 0;
-            for (j = i; j < dim; ++j) {
-                for (k = 0; k < G.ng[j]; ++k) {
-                    H[nH] = G.g[j][k];
-                    ++nH;
-                }
-            }
-            G.ord[i] = orbitlen(fp.e[i], fp.diag[i], H, nH, V);
-        }
-        else
-            G.ord[i] = 1;
-    }
-    free(H);
-    /* compute the full automorphism group */
-    autom(&G, V, F, fp, comb, bach, flags);
-    /* print the generators of the group, which are necessary for generating
-     */
-    B = putgens(G, flags);
-    n = 0;
-    for (i = flags.STAB; i < dim; ++i) {
-        if (G.ord[i] > 1)
-            ++n;
-    }
-    /* print a base to AUTO.tmp if the print-flag is set */
-    if (flags.PRINT == 1) {
-        outfile = fopen("AUTO.tmp", "a");
-        fprintf(outfile, "%dx%d\n", n, dim);
-        for (i = flags.STAB; i < dim; ++i) {
-            if (G.ord[i] > 1) {
-                for (j = 0; j < dim; ++j)
-                    fprintf(outfile, " %d", V.v[fp.e[i]][j]);
-                fprintf(outfile, "\n");
-            }
-        }
-        fclose(outfile);
-    }
-    /* print the order of the group */
-    putord(G, flags, B);
+                i = 0;
+		while (nH+fail < ngen)
+		{
+		    if ((H[nH] = (int**)malloc(dim * sizeof(int*))) == 0)
+			exit (2);
+                    for(j=0;j<dim;j++)
+                    {
+		      if ((H[nH][j] = (int*)malloc(dim * sizeof(int))) == 0)
+		  	exit (2);
+                      for(k=0;k<dim;k++)
+                        H[nH][j][k] = Erz[i]->array.SZ[k][j];
+                    }
+/* check whether the matrix is really an automorphism, i.e. fixes the forms */
+			if (checkgen(H[nH], F) == 0)
+/* the matrix is not an automorphism */
+			{
+				++fail;
+				for (j = 0; j < dim; ++j)
+					free(H[nH][j]);
+                                free(H[nH]);
+			}
+			else
+/* the matrix fixes all forms in F */
+				++nH;
+                    i++;
+		}
+	}
+	else
+		nH = 0;
 
 
-    if (flags.BACH[0] == 1) {
-        for (i = 0; i < flags.BACHDEP; ++i)
-            free(bach[i].coef);
-        free(bach);
-    }
-    if (flags.DEPTH > 0) {
-        for (i = 0; i < dim; i++) {
-            for (j = 0; j <= comb[i].list.n; j++)
+
+	V.dim = dim;
+	V.len = dim + F.n;
+/* get the short vectors */
+        V.n = SV->rows;
+        if ((V.v = (int**)malloc((V.n+1) * sizeof(int*))) == 0)
+			exit (2);
+        for(i=0;i<=V.n;i++)
+        {
+          if ((V.v[i] = (int*)malloc(V.len * sizeof(int))) == 0)
+			exit (2);
+        }
+        for(i=1;i<= V.n;i++)
+        {
+            for(j=0;j<=dim;j++)
+               V.v[i][j] = SV->array.SZ[i-1][j];
+        }
+/* the first nonzero entry of each vector is made positive and the maximal
+   entry of the vectors is determined */
+	max = 1;
+	for (i = 1; i <= V.n; ++i)
+	{
+		Vvi = V.v[i];
+		for (j = 0; j < dim  &&  Vvi[j] == 0; ++j);
+		if (j < dim  &&  Vvi[j] < 0)
+		{
+			for (k = j; k < dim; ++k)
+				Vvi[k] *= -1;
+		}
+		for (k = j; k < dim; ++k)
+		{
+			if (abs(Vvi[k]) > max)
+				max = abs(Vvi[k]);
+		}
+	}
+	if (max > MAXENTRY)
+/* there is an entry, which is bigger than MAXENTRY, which might cause overflow,
+   since the program doesn't use long integer arithmetic */
+	{
+		fprintf(stderr, "Error: Found entry %d in short vectors.\nTo avoid overflow, the entries should not exceed %d.\n", max, MAXENTRY);
+		exit (3);
+	}
+/* V.prime is a prime p, such that every entry x in the short vectors remains
+   unchanged under reduction mod p in symmetric form, i.e. -p/2 < x <= p/2 */
+	for (V.prime = 2*max + 1; isprime(V.prime) == 0; ++V.prime);
+/* sort the vectors and delete doublets */
+	sortvecs(&V);
+/* the norm-vector (i.e. the vector of the norms with respect to the different
+   invariant forms) of each vector must be equal to the norm-vector of one
+   of the vectors from the standard-base */
+	if ((norm.v = (int**)malloc((dim+1) * sizeof(int*))) == 0)
+		exit (2);
+	norm.n = dim;
+	norm.dim = F.n;
+	norm.len = F.n;
+	for (i = 1; i <= norm.n; ++i)
+	{
+/* norm.v[i] is the norm combination of the (i-1)-th base-vector */
+		if ((norm.v[i] = (int*)malloc(norm.dim * sizeof(int))) == 0)
+			exit (2);
+		for (k = 0; k < norm.dim; ++k)
+			norm.v[i][k] = F.A[k][i-1][i-1];
+	}
+	sortvecs(&norm);
+/* delete those vectors, which can not be the image of any of the standard-base
+   vectors */
+	checkvecs(&V, F, norm);
+	for (i = 1; i <= norm.n; ++i)
+		free(norm.v[i]);
+	free(norm.v);
+/* print the invariant forms, if output is in ASCII-format */
+/*********************************************
+		printf("#%d\n", F.n);
+		for (i = 0; i < F.n; ++i)
+			putform(F.A[i], dim);
+**********************************************/
+/* F.v[i][j] is the transposed of the product of the Gram-matrix F.A[i] with the
+   transposed of the vector v[j], hence the scalar product of v[j] and v[k] with
+   respect to the Gram-matrix F.A[i] can be computed as standard scalar product
+   of v[j] and F.v[i][k] */
+	if ((F.v = (int***)malloc(F.n * sizeof(int**))) == 0)
+		exit (2);
+/* the product of the maximal entry in the short vectors with the maximal entry
+   in F.v[i] should not exceed MAXNORM to avoid overflow */
+	max = MAXNORM / max;
+	for (i = 0; i < F.n; ++i)
+	{
+		FAi = F.A[i];
+		if ((F.v[i] = (int**)malloc((V.n+1) * sizeof(int*))) == 0)
+			exit (2);
+		Fvi = F.v[i];
+		for (j = 1; j <= V.n; ++j)
+		{
+			Vvj = V.v[j];
+			if ((Fvi[j] = (int*)malloc(dim * sizeof(int))) == 0)
+				exit (2);
+			Fvij = Fvi[j];
+			for (k = 0; k < dim; ++k)
+			{
+				Fvij[k] = sscp(FAi[k], Vvj, dim);
+				if (abs(Fvij[k]) > max)
+/* some entry in F.v[i] is too large */
+				{
+					fprintf(stderr, "Error: Found entry %d in F.v.\nTo avoid overflow, the entries should not exceed %d.\n", Fvij[k], max);
+					exit (3);
+				}
+			}
+		}
+	}
+/* fp.per is the order in which the images of the base-vectors are set */
+	if ((fp.per = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+/* fp.e[i] is the index in V.v of the i-th vector of the standard-base in the 
+   new order */
+	if ((fp.e = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+/* fp.diag is the diagonal of the fingerprint in the new order, fp.diag[i] is
+   an upper bound for the length of the orbit of the i-th base-vector under
+   the stabilizer of the preceding ones */
+	if ((fp.diag = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+/* compute the fingerprint */
+	fingerprint(&fp, F, V);
+	if (flags.PRINT == 1)
+/* if the -P option is given, print the diagonal fp.diag and the number of short
+   vectors on AUTO.tmp */
+	{
+		outfile = fopen("AUTO.tmp", "a");
+		fprintf(outfile, "%d short vectors\n", 2*V.n);
+		fprintf(outfile, "fingerprint diagonal:\n");
+		for (i = 0; i < dim; ++i)
+			fprintf(outfile, " %2d", fp.diag[i]);
+		fprintf(outfile, "\n");
+		fclose(outfile);
+	}
+/* get the standard basis in the new order */
+	if ((vec = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+	for (i = 0; i < dim; ++i)
+	{
+		for (j = 0; j < dim; ++j)
+			vec[j] = 0;
+		vec[fp.per[i]] = 1;
+		fp.e[i] = numberof(vec, V);
+		if (abs(fp.e[i]) > V.n)
+/* the standard-base must occur in the set of short vectors, since Id is
+   certainly an automorphism */
+		{
+			fprintf(stderr, "Error: standard basis vector nr. %d not found\n", i);
+			exit (2);
+		}
+	}
+	free(vec);
+/* if the -D option is given, the scalar product combinations and the 
+   corresponding vector sums are computed for the standard-basis */
+	if (flags.DEPTH > 0)
+	{
+		if ((comb = (scpcomb*)malloc(dim * sizeof(scpcomb))) == 0)
+			exit (2);
+		for (i = 0; i < dim; ++i)
+		{
+/* compute the list of scalar product combinations and the corresponding
+   vector sums */
+			scpvecs(&comb[i].list, &sumveclist, i, fp.e, flags.DEPTH, V, F);
+/* compute a basis for the lattice that is generated by the vector sums and
+   a transformation matrix that expresses the basis in terms of the 
+   vector sums */
+			base(&comb[i], &sumvecbase, sumveclist, F.A[0], dim);
+			if (flags.PRINT == 1)
+/* if the -P option is given, print the rank of the lattice generated by the
+   vector sums on level i on AUTO.tmp */
+			{
+				outfile = fopen("AUTO.tmp", "a");
+				fprintf(outfile, "comb[%d].rank = %d\n", i, comb[i].rank);
+				fclose(outfile);
+			}
+/* compute the coefficients of the vector sums in terms of the basis */
+			coef(&comb[i], sumvecbase, sumveclist, F.A[0], dim);
+			for (j = 0; j <= comb[i].list.n; ++j)
+				free(sumveclist[j]);
+			free(sumveclist);
+/* compute the scalar products of the base-vectors */
+			scpforms(&comb[i], sumvecbase, F);
+			for (j = 0; j < comb[i].rank; ++j)
+				free(sumvecbase[j]);
+			free(sumvecbase);
+		}
+	}
+/* the Bacher-polynomials for the first BACHDEP base-vectors are computed,
+   if no scalar product was given as an argument, the scalar product is set
+   to 1/2 the norm of the base-vector (with respect to the first form) */
+	if (flags.BACH[0] == 1)
+	{
+		if ((bach = (bachpol*)malloc(flags.BACHDEP * sizeof(bachpol))) == 0)
+			exit (2);
+		for (i = 0; i < flags.BACHDEP; ++i)
+		{
+			if (flags.BACH[2] == 0)
+/* no scalar product was given as an option */
+				flags.BACHSCP = V.v[fp.e[i]][dim] / 2;
+/* compute the Bacher-polynomial */
+			bacher(&bach[i], fp.e[i], flags.BACHSCP, V, F.v[0]);
+			if (flags.PRINT == 1)
+/* if the -P option is given, print the Bacher-polynomial on AUTO.tmp */
+			{
+				outfile = fopen("AUTO.tmp", "a");
+				fprintf(outfile, "Bacher-polynomial of base vector fp.e[%d]:\n", i);
+				fputbach(outfile, bach[i]);
+				fclose(outfile);
+			}
+		}
+	}
+/* set up the group: the generators in G.g[i] are matrices that fix the
+   first i base-vectors but do not fix fp.e[i] */
+	if ((G.g = (int****)malloc(dim * sizeof(int***))) == 0)
+		exit (2);
+/* G.ng is the number of generators in G.g[i] */
+	if ((G.ng = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+/* the first G.nsg[i] generators in G.g[i] are obtained as stabilizer elements
+   and are not necessary to generate the group */
+	if ((G.nsg = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+/* G.ord[i] is the orbit length of fp.e[i] under the generators in 
+   G.g[i] ... G.g[dim-1] */
+	if ((G.ord = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+	for (i = 0; i < dim; ++i)
+	{
+		if ((G.g[i] = (int***)malloc(1 * sizeof(int**))) == 0)
+			exit (2);
+		G.ng[i] = 0;
+		G.nsg[i] = 0;
+	}
+	G.dim = dim;
+	if ((G.g[0][0] = (int**)malloc(dim * sizeof(int*))) == 0)
+		exit (2);
+/* -Id is always an automorphism */
+	for (i = 0; i < dim; ++i)
+	{
+		if ((G.g[0][0][i] = (int*)malloc(dim * sizeof(int))) == 0)
+			exit (2);
+		for (j = 0; j < dim; ++j)
+			G.g[0][0][i][j] = 0;
+		G.g[0][0][i][i] = -1;
+		G.ng[0] = 1;
+	}
+/* fill in the generators which were given as input */
+	for (i = 0; i < nH; ++i)
+	{
+		for (j = 0; j < dim  &&  operate(fp.e[j], H[i], V) == fp.e[j]; ++j);
+		if (j < dim)
+/* the generator is not Id and fixes fp.e[0],...,fp.e[j-1] but not fp.e[j] */
+		{
+			++G.ng[j];
+			if ((G.g[j] = (int***)realloc(G.g[j], G.ng[j] * sizeof(int**))) == 0)
+				exit (2);
+			if ((G.g[j][G.ng[j]-1] = (int**)malloc(dim * sizeof(int*))) == 0)
+				exit (2);
+			for (k = 0; k < dim; ++k)
+			{
+				if ((G.g[j][G.ng[j]-1][k] = (int*)malloc(dim * sizeof(int))) == 0)
+					exit (2);
+				for (l = 0; l < dim; ++l)
+					G.g[j][G.ng[j]-1][k][l] = H[i][k][l];
+			}
+		}
+		for (k = 0; k < dim; ++k)
+			free(H[i][k]);
+		free(H[i]);
+	}
+	if (nH > 0)
+		free(H);
+	nH = 0;
+	for (i = 0; i < dim; ++i)
+		nH += G.ng[i];
+	if ((H = (int***)malloc(nH * sizeof(int**))) == 0)
+		exit (2);
+/* calculate the orbit lengths under the automorphisms known so far */
+	for (i = 0; i < dim; ++i)
+	{
+		if (G.ng[i] > 0)
+		{
+			nH = 0;
+			for (j = i; j < dim; ++j)
+			{
+				for (k = 0; k < G.ng[j]; ++k)
+				{
+					H[nH] = G.g[j][k];
+					++nH;
+				}
+			}
+			G.ord[i] = orbitlen(fp.e[i], fp.diag[i], H, nH, V);
+		}
+		else
+			G.ord[i] = 1;
+	}
+	free(H);
+/* compute the full automorphism group */
+	autom(&G, V, F, fp, comb, bach, flags);
+/* print the generators of the group, which are necessary for generating */
+	B = putgens(G, flags);
+	n = 0;
+	for (i = flags.STAB; i < dim; ++i)
+	{
+		if (G.ord[i] > 1)
+			++n;
+	}
+/* print a base to AUTO.tmp if the print-flag is set */
+	if (flags.PRINT == 1)
+	{
+		outfile = fopen("AUTO.tmp", "a");
+		fprintf(outfile, "%dx%d\n", n, dim);
+		for (i = flags.STAB; i < dim; ++i)
+		{
+			if (G.ord[i] > 1)
+			{
+				for (j = 0; j < dim; ++j)
+					fprintf(outfile, " %d", V.v[fp.e[i]][j]);
+				fprintf(outfile, "\n");
+			}
+		}
+		fclose(outfile);
+	}
+/* print the order of the group */
+	putord(G, flags, B);
+
+
+	if (flags.BACH[0] == 1)
+	{
+		for (i = 0; i < flags.BACHDEP; ++i)
+                   free(bach[i].coef);
+                free(bach);
+        }
+	if (flags.DEPTH > 0)
+	{
+            for(i=0;i<dim;i++)
+            {
+              for(j=0;j<=comb[i].list.n;j++)
                 free(comb[i].coef[j]);
-            free(comb[i].coef);
-            for (j = 0; j <= comb[i].list.n; j++)
+              free(comb[i].coef);
+              for(j=0;j<=comb[i].list.n;j++)
                 free(comb[i].list.v[j]);
-            free(comb[i].list.v);
-            for (j = 0; j < comb[i].rank; j++)
+              free(comb[i].list.v);
+              for(j=0;j<comb[i].rank;j++)
                 free(comb[i].trans[j]);
-            free(comb[i].trans);
-            for (j = 0; j < F.n; j++) {
-                for (k = 0; k < comb[i].rank; k++)
+              free(comb[i].trans);
+              for(j=0;j<F.n;j++)
+              {
+                 for(k=0;k<comb[i].rank;k++)
                     free(comb[i].F[j][k]);
-                free(comb[i].F[j]);
+                 free(comb[i].F[j]);
+              }
+              free(comb[i].F);
             }
-            free(comb[i].F);
+            free(comb);
         }
-        free(comb);
-    }
-    for (i = 0; i < F.n; i++) {
-        for (j = 1; j <= V.n; j++)
+        for(i=0;i<F.n;i++)
+        {
+          for(j=1;j<=V.n;j++)
             free(F.v[i][j]);
-        free(F.v[i]);
-        for (j = 0; j < dim; j++)
+          free(F.v[i]);
+          for(j=0;j<dim;j++)
             free(F.A[i][j]);
-        free(F.A[i]);
-    }
-    free(F.A);
-    free(F.v);
-    for (i = 0; i <= V.n; i++)
-        free(V.v[i]);
-    free(V.v);
-    free(fp.diag);
-    free(fp.per);
-    free(fp.e);
-    for (i = 0; i < dim; i++) {
-        for (j = 0; j < G.ng[i]; j++) {
-            for (k = 0; k < dim; k++)
-                free(G.g[i][j][k]);
-            free(G.g[i][j]);
+          free(F.A[i]);
         }
-        free(G.g[i]);
-    }
-    free(G.g);
-    free(G.ord);
-    free(G.ng);
-    free(G.nsg);
+        free(F.A); free(F.v);
+        for(i=0;i<=V.n;i++)
+          free(V.v[i]);
+        free(V.v);
+        free(fp.diag); free(fp.per); free(fp.e);
+        for(i=0;i<dim;i++)
+        {
+           for(j=0;j<G.ng[i];j++)
+           {
+             for(k=0;k<dim;k++)
+               free(G.g[i][j][k]);
+             free(G.g[i][j]);
+           }
+           free(G.g[i]);
+        }
+        free(G.g); free(G.ord); free(G.ng); free(G.nsg);
 
-    return (B);
+        return(B);
 }
 
 
@@ -572,7 +581,7 @@ bravais_TYP * autgrp(matrix_TYP ** Fo,
 @ Pbase:    a set of matrices
 @ Pdim:     the number of matrices given in 'Pbase'.
 @
-@ This function is designed to calculate the stabilizer of a perfect
+@ This function is designed to calculate the stabilizer of a perfect 
 @ form 'Fo' in the normalizer of the group generated by the matrices
 @ given in 'Erz'.
 @ Then 'P' is the set of matrices given by the Voronoi-directions of 'Fo'
@@ -583,490 +592,493 @@ bravais_TYP * autgrp(matrix_TYP ** Fo,
 \**************************************************************************/
 
 
-bravais_TYP * perfect_normal_autgrp(matrix_TYP *  Fo,
-                                    matrix_TYP *  SV,
-                                    matrix_TYP ** Erz,
-                                    int           Erzanz,
-                                    int *         options,
-                                    matrix_TYP ** P,
-                                    int           Panz,
-                                    matrix_TYP ** Pbase,
-                                    int           Pdim)
+bravais_TYP *
+perfect_normal_autgrp (matrix_TYP *Fo, matrix_TYP *SV, matrix_TYP **Erz, int Erzanz, int *options, matrix_TYP **P, int Panz, matrix_TYP **Pbase, int Pdim)
 {
-    FILE *        outfile;
-    bachpol *     bach = 0;
-    flagstruct    flags;
-    scpcomb *     comb = 0;
-    group         G;
-    invar         F;
-    veclist       V, norm;
-    fpstruct      fp;
-    int           dim, max, fail, *vec;
-    int ***       H = 0, nH = 0, ngen, **sumveclist, **sumvecbase;
-    int           i, j, k, l, n, *Vvi, *Vvj, **Fvi, *Fvij, **FAi;
-    bravais_TYP * B;
+	FILE		*outfile;
+	bachpol		*bach = 0;
+	flagstruct	flags;
+	scpcomb		*comb = 0;
+	group		G;
+	invar		F;
+	veclist		V, norm;
+	fpstruct	fp;
+	int		dim, max, fail, *vec;
+	int		***H = 0, nH = 0, ngen, **sumveclist, **sumvecbase;
+	int		i, j, k, l, n, *Vvi, *Vvj, **Fvi, *Fvij, **FAi;
+        bravais_TYP *B;
 
-    normal_option = TRUE;
-    perp_no = Panz;
-    perpdim = Pdim;
-    /* get the flags from the command line */
-    getflags(&flags, options);
-    if (Erzanz > 0)
-        flags.GEN = 1;
-    else
-        flags.GEN = 0;
-    /* F.n is the number of invariant forms */
-    F.n = 1;
-    if ((F.A = (int ***)malloc(1 * sizeof(int **))) == 0)
-        exit(2);
-    /* read the invariant forms */
-    F.dim = Fo->cols;
-    dim = F.dim;
-    if (Fo->cols != F.dim || Fo->rows != F.dim) {
-        printf("error form 'Fo' in autgrp must be a square matrix\n");
-        exit(3);
-    }
-    if ((F.A[0] = (int **)malloc(dim * sizeof(int *))) == 0)
-        exit(2);
-    for (j = 0; j < F.dim; j++) {
-        if ((F.A[0][j] = (int *)malloc(dim * sizeof(int))) == 0)
-            exit(2);
-        for (k = 0; k < F.dim; k++)
-            F.A[0][j][k] = Fo->array.SZ[j][k];
-    }
-    if (flags.GEN == 1)
-    /* some automorphisms are already known */
-    {
-        ngen = Erzanz;
-        if ((H = (int ***)malloc(ngen * sizeof(int **))) == 0)
-            exit(2);
-        nH = 0;
-        fail = 0;
-        for (i = 0; i < ngen; i++) {
-            if (Erz[i]->cols != dim || Erz[i]->rows != dim) {
-                printf("Elements 'Erz' have wrong dimension\n");
-                exit(2);
-            }
-        }
-        i = 0;
-        while (nH + fail < ngen) {
-            if ((H[nH] = (int **)malloc(dim * sizeof(int *))) == 0)
-                exit(2);
-            for (j = 0; j < dim; j++) {
-                if ((H[nH][j] = (int *)malloc(dim * sizeof(int))) == 0)
-                    exit(2);
-                for (k = 0; k < dim; k++)
-                    H[nH][j][k] = Erz[i]->array.SZ[k][j];
-            }
-            /* check whether the matrix is really an automorphism, i.e. fixes
-             * the forms */
-            if (checkgen(H[nH], F) == 0)
-            /* the matrix is not an automorphism */
-            {
-                ++fail;
-                for (j = 0; j < dim; ++j)
-                    free(H[nH][j]);
-                free(H[nH]);
-            }
-            else
-                /* the matrix fixes all forms in F */
-                ++nH;
-            i++;
-        }
-    }
-    else
-        nH = 0;
-
-
-    V.dim = dim;
-    V.len = dim + F.n;
-    /* get the short vectors */
-    V.n = SV->rows;
-    if ((V.v = (int **)malloc((V.n + 1) * sizeof(int *))) == 0)
-        exit(2);
-    if ((V.v[0] = (int *)malloc(V.len * sizeof(int))) == 0)
-        exit(2);
-    /* tilman 9/1/97 changed these lines
-    for(i=1;i<= V.n;i++)
-    {
-           V.v[i] = SV->array.SZ[i-1];
-    } to (next 5 lines): */
-    for (i = 1; i <= V.n; i++) {
-        V.v[i] = (int *)malloc((SV->rows + 1) * sizeof(int));
-        for (j = 0; j < SV->cols; j++) {
-            V.v[i][j] = SV->array.SZ[i - 1][j];
-        }
-    }
-
-    /* the first nonzero entry of each vector is made positive and the maximal
-       entry of the vectors is determined */
-    max = 1;
-    for (i = 1; i <= V.n; ++i) {
-        Vvi = V.v[i];
-        for (j = 0; j < dim && Vvi[j] == 0; ++j)
-            ;
-        if (j < dim && Vvi[j] < 0) {
-            for (k = j; k < dim; ++k)
-                Vvi[k] *= -1;
-        }
-        for (k = j; k < dim; ++k) {
-            if (abs(Vvi[k]) > max)
-                max = abs(Vvi[k]);
-        }
-    }
-    if (max > MAXENTRY)
-    /* there is an entry, which is bigger than MAXENTRY, which might cause
-       overflow, since the program doesn't use long integer arithmetic */
-    {
-        fprintf(stderr,
-                "Error: Found entry %d in short vectors.\nTo avoid overflow, "
-                "the entries should not exceed %d.\n",
-                max, MAXENTRY);
-        exit(3);
-    }
-    /* V.prime is a prime p, such that every entry x in the short vectors
-       remains
-       unchanged under reduction mod p in symmetric form, i.e. -p/2 < x <= p/2
-     */
-    for (V.prime = 2 * max + 1; isprime(V.prime) == 0; ++V.prime)
-        ;
-    /* sort the vectors and delete doublets */
-    sortvecs(&V);
-    /* the norm-vector (i.e. the vector of the norms with respect to the
-       different invariant forms) of each vector must be equal to the
-       norm-vector of one of the vectors from the standard-base */
-    if ((norm.v = (int **)malloc((dim + 1) * sizeof(int *))) == 0)
-        exit(2);
-    norm.n = dim;
-    norm.dim = F.n;
-    norm.len = F.n;
-    for (i = 1; i <= norm.n; ++i) {
-        /* norm.v[i] is the norm combination of the (i-1)-th base-vector */
-        if ((norm.v[i] = (int *)malloc(norm.dim * sizeof(int))) == 0)
-            exit(2);
-        for (k = 0; k < norm.dim; ++k)
-            norm.v[i][k] = F.A[k][i - 1][i - 1];
-    }
-    sortvecs(&norm);
-    /* delete those vectors, which can not be the image of any of the
-       standard-base vectors */
-    checkvecs(&V, F, norm);
-    for (i = 1; i <= norm.n; ++i)
-        free(norm.v[i]);
-    free(norm.v);
-    /* print the invariant forms, if output is in ASCII-format */
-    /*********************************************
-                    printf("#%d\n", F.n);
-                    for (i = 0; i < F.n; ++i)
-                            putform(F.A[i], dim);
-    **********************************************/
-    /* F.v[i][j] is the transposed of the product of the Gram-matrix F.A[i]
-       with the transposed of the vector v[j], hence the scalar product of
-       v[j] and v[k] with respect to the Gram-matrix F.A[i] can be computed as
-       standard scalar product of v[j] and F.v[i][k] */
-    if ((F.v = (int ***)malloc(F.n * sizeof(int **))) == 0)
-        exit(2);
-    /* the product of the maximal entry in the short vectors with the maximal
-       entry in F.v[i] should not exceed MAXNORM to avoid overflow */
-    max = MAXNORM / max;
-    for (i = 0; i < F.n; ++i) {
-        FAi = F.A[i];
-        if ((F.v[i] = (int **)malloc((V.n + 1) * sizeof(int *))) == 0)
-            exit(2);
-        Fvi = F.v[i];
-        for (j = 1; j <= V.n; ++j) {
-            Vvj = V.v[j];
-            if ((Fvi[j] = (int *)malloc(dim * sizeof(int))) == 0)
-                exit(2);
-            Fvij = Fvi[j];
-            for (k = 0; k < dim; ++k) {
-                Fvij[k] = sscp(FAi[k], Vvj, dim);
-                if (abs(Fvij[k]) > max)
-                /* some entry in F.v[i] is too large */
+        normal_option = TRUE;
+        perp_no = Panz;
+        perpdim = Pdim;
+/* get the flags from the command line */
+	getflags(&flags, options);
+   if(Erzanz > 0)
+     flags.GEN = 1;
+   else
+     flags.GEN = 0;
+/* F.n is the number of invariant forms */
+	F.n = 1;
+	if ((F.A = (int***)malloc(1 *sizeof(int**))) == 0)
+		exit (2);
+/* read the invariant forms */
+        F.dim = Fo->cols;
+	dim = F.dim;
+         if(Fo->cols != F.dim || Fo->rows != F.dim)
+         {
+            printf("error form 'Fo' in autgrp must be a square matrix\n");
+            exit(3);
+         }
+	  if ((F.A[0] = (int**)malloc(dim * sizeof(int*))) == 0)
+		exit (2);
+          for(j=0;j<F.dim;j++)
+          {
+	    if ((F.A[0][j] = (int*)malloc(dim * sizeof(int))) == 0)
+		  exit (2);
+            for(k=0;k<F.dim;k++)
+              F.A[0][j][k] = Fo->array.SZ[j][k];
+          }
+	if (flags.GEN == 1)
+/* some automorphisms are already known */
+	{
+		ngen = Erzanz;
+		if ((H = (int***)malloc(ngen * sizeof(int**))) == 0)
+			exit (2);
+		nH = 0;
+		fail = 0;
+                for(i=0;i<ngen;i++)
                 {
-                    fprintf(stderr,
-                            "Error: Found entry %d in F.v.\nTo avoid "
-                            "overflow, the entries should not exceed %d.\n",
-                            Fvij[k], max);
-                    exit(3);
-                }
-            }
-        }
-    }
-    /* fp.per is the order in which the images of the base-vectors are set */
-    if ((fp.per = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    /* fp.e[i] is the index in V.v of the i-th vector of the standard-base in
-       the new order */
-    if ((fp.e = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    /* fp.diag is the diagonal of the fingerprint in the new order, fp.diag[i]
-       is an upper bound for the length of the orbit of the i-th base-vector
-       under the stabilizer of the preceding ones */
-    if ((fp.diag = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    /* compute the fingerprint */
-    fingerprint(&fp, F, V);
-    mach_perp_matrices(fp, P, Pbase, dim);
-    pointer_mat_quicksort(perp, 0, perp_no - 1, dim, dim,
-                          pointer_lower_triangular_mat_comp);
-    if (flags.PRINT == 1)
-    /* if the -P option is given, print the diagonal fp.diag and the number of
-       short vectors on AUTO.tmp */
-    {
-        outfile = fopen("AUTO.tmp", "a");
-        fprintf(outfile, "%d short vectors\n", 2 * V.n);
-        fprintf(outfile, "fingerprint diagonal:\n");
-        for (i = 0; i < dim; ++i)
-            fprintf(outfile, " %2d", fp.diag[i]);
-        fprintf(outfile, "\n");
-        fclose(outfile);
-    }
-    /* get the standard basis in the new order */
-    if ((vec = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    for (i = 0; i < dim; ++i) {
-        for (j = 0; j < dim; ++j)
-            vec[j] = 0;
-        vec[fp.per[i]] = 1;
-        fp.e[i] = numberof(vec, V);
-        if (abs(fp.e[i]) > V.n)
-        /* the standard-base must occur in the set of short vectors, since Id
-           is certainly an automorphism */
-        {
-            fprintf(stderr, "Error: standard basis vector nr. %d not found\n",
-                    i);
-            exit(3);
-        }
-    }
-    free(vec);
-    /* if the -D option is given, the scalar product combinations and the
-       corresponding vector sums are computed for the standard-basis */
-    if (flags.DEPTH > 0) {
-        if ((comb = (scpcomb *)malloc(dim * sizeof(scpcomb))) == 0)
-            exit(3);
-        for (i = 0; i < dim; ++i) {
-            /* compute the list of scalar product combinations and the
-               corresponding vector sums */
-            scpvecs(&comb[i].list, &sumveclist, i, fp.e, flags.DEPTH, V, F);
-            /* compute a basis for the lattice that is generated by the vector
-               sums and a transformation matrix that expresses the basis in
-               terms of the vector sums */
-            base(&comb[i], &sumvecbase, sumveclist, F.A[0], dim);
-            if (flags.PRINT == 1)
-            /* if the -P option is given, print the rank of the lattice
-               generated by the vector sums on level i on AUTO.tmp */
-            {
-                outfile = fopen("AUTO.tmp", "a");
-                fprintf(outfile, "comb[%d].rank = %d\n", i, comb[i].rank);
-                fclose(outfile);
-            }
-            /* compute the coefficients of the vector sums in terms of the
-             * basis */
-            coef(&comb[i], sumvecbase, sumveclist, F.A[0], dim);
-            for (j = 0; j <= comb[i].list.n; ++j)
-                free(sumveclist[j]);
-            free(sumveclist);
-            /* compute the scalar products of the base-vectors */
-            scpforms(&comb[i], sumvecbase, F);
-            for (j = 0; j < comb[i].rank; ++j)
-                free(sumvecbase[j]);
-            free(sumvecbase);
-        }
-    }
-    /* the Bacher-polynomials for the first BACHDEP base-vectors are computed,
-       if no scalar product was given as an argument, the scalar product is
-       set
-       to 1/2 the norm of the base-vector (with respect to the first form) */
-    if (flags.BACH[0] == 1) {
-        if ((bach = (bachpol *)malloc(flags.BACHDEP * sizeof(bachpol))) == 0)
-            exit(2);
-        for (i = 0; i < flags.BACHDEP; ++i) {
-            if (flags.BACH[2] == 0)
-                /* no scalar product was given as an option */
-                flags.BACHSCP = V.v[fp.e[i]][dim] / 2;
-            /* compute the Bacher-polynomial */
-            bacher(&bach[i], fp.e[i], flags.BACHSCP, V, F.v[0]);
-            if (flags.PRINT == 1)
-            /* if the -P option is given, print the Bacher-polynomial on
-               AUTO.tmp */
-            {
-                outfile = fopen("AUTO.tmp", "a");
-                fprintf(outfile,
-                        "Bacher-polynomial of base vector fp.e[%d]:\n", i);
-                fputbach(outfile, bach[i]);
-                fclose(outfile);
-            }
-        }
-    }
-    /* set up the group: the generators in G.g[i] are matrices that fix the
-       first i base-vectors but do not fix fp.e[i] */
-    if ((G.g = (int ****)malloc(dim * sizeof(int ***))) == 0)
-        exit(2);
-    /* G.ng is the number of generators in G.g[i] */
-    if ((G.ng = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    /* the first G.nsg[i] generators in G.g[i] are obtained as stabilizer
-       elements and are not necessary to generate the group */
-    if ((G.nsg = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    /* G.ord[i] is the orbit length of fp.e[i] under the generators in
-       G.g[i] ... G.g[dim-1] */
-    if ((G.ord = (int *)malloc(dim * sizeof(int))) == 0)
-        exit(2);
-    for (i = 0; i < dim; ++i) {
-        if ((G.g[i] = (int ***)malloc(1 * sizeof(int **))) == 0)
-            exit(2);
-        G.ng[i] = 0;
-        G.nsg[i] = 0;
-    }
-    G.dim = dim;
-    if ((G.g[0][0] = (int **)malloc(dim * sizeof(int *))) == 0)
-        exit(2);
-    /* -Id is always an automorphism */
-    for (i = 0; i < dim; ++i) {
-        if ((G.g[0][0][i] = (int *)malloc(dim * sizeof(int))) == 0)
-            exit(2);
-        for (j = 0; j < dim; ++j)
-            G.g[0][0][i][j] = 0;
-        G.g[0][0][i][i] = -1;
-        G.ng[0] = 1;
-    }
-    /* fill in the generators which were given as input */
-    for (i = 0; i < nH; ++i) {
-        for (j = 0; j < dim && operate(fp.e[j], H[i], V) == fp.e[j]; ++j)
-            ;
-        if (j < dim)
-        /* the generator is not Id and fixes fp.e[0],...,fp.e[j-1] but not
-           fp.e[j] */
-        {
-            ++G.ng[j];
-            if ((G.g[j] =
-                     (int ***)realloc(G.g[j], G.ng[j] * sizeof(int **))) == 0)
-                exit(2);
-            if ((G.g[j][G.ng[j] - 1] = (int **)malloc(dim * sizeof(int *))) ==
-                0)
-                exit(2);
-            for (k = 0; k < dim; ++k) {
-                if ((G.g[j][G.ng[j] - 1][k] =
-                         (int *)malloc(dim * sizeof(int))) == 0)
+                  if(Erz[i]->cols != dim || Erz[i]->rows != dim)
+                  {
+                    printf("Elements 'Erz' have wrong dimension\n");
                     exit(2);
-                for (l = 0; l < dim; ++l)
-                    G.g[j][G.ng[j] - 1][k][l] = H[i][k][l];
-            }
-        }
-        for (k = 0; k < dim; ++k)
-            free(H[i][k]);
-        free(H[i]);
-    }
-    if (nH > 0)
-        free(H);
-    nH = 0;
-    for (i = 0; i < dim; ++i)
-        nH += G.ng[i];
-    if ((H = (int ***)malloc(nH * sizeof(int **))) == 0)
-        exit(2);
-    /* calculate the orbit lengths under the automorphisms known so far */
-    for (i = 0; i < dim; ++i) {
-        if (G.ng[i] > 0) {
-            nH = 0;
-            for (j = i; j < dim; ++j) {
-                for (k = 0; k < G.ng[j]; ++k) {
-                    H[nH] = G.g[j][k];
-                    ++nH;
+                  }
                 }
-            }
-            G.ord[i] = orbitlen(fp.e[i], fp.diag[i], H, nH, V);
-        }
-        else
-            G.ord[i] = 1;
-    }
-    free(H);
-    /* compute the full automorphism group */
-    autom(&G, V, F, fp, comb, bach, flags);
-    /* print the generators of the group, which are necessary for generating
-     */
-    B = putgens(G, flags);
-    n = 0;
-    for (i = flags.STAB; i < dim; ++i) {
-        if (G.ord[i] > 1)
-            ++n;
-    }
-    /* print a base to AUTO.tmp if the print-flag is set */
-    if (flags.PRINT == 1) {
-        outfile = fopen("AUTO.tmp", "a");
-        fprintf(outfile, "%dx%d\n", n, dim);
-        for (i = flags.STAB; i < dim; ++i) {
-            if (G.ord[i] > 1) {
-                for (j = 0; j < dim; ++j)
-                    fprintf(outfile, " %d", V.v[fp.e[i]][j]);
-                fprintf(outfile, "\n");
-            }
-        }
-        fclose(outfile);
-    }
-    /* print the order of the group */
-    putord(G, flags, B);
+                i = 0;
+		while (nH+fail < ngen)
+		{
+		    if ((H[nH] = (int**)malloc(dim * sizeof(int*))) == 0)
+			exit (2);
+                    for(j=0;j<dim;j++)
+                    {
+		      if ((H[nH][j] = (int*)malloc(dim * sizeof(int))) == 0)
+		  	exit (2);
+                      for(k=0;k<dim;k++)
+                        H[nH][j][k] = Erz[i]->array.SZ[k][j];
+                    }
+/* check whether the matrix is really an automorphism, i.e. fixes the forms */
+			if (checkgen(H[nH], F) == 0)
+/* the matrix is not an automorphism */
+			{
+				++fail;
+				for (j = 0; j < dim; ++j)
+					free(H[nH][j]);
+                                free(H[nH]);
+			}
+			else
+/* the matrix fixes all forms in F */
+				++nH;
+                    i++;
+		}
+	}
+	else
+		nH = 0;
 
 
-    if (flags.BACH[0] == 1) {
-        for (i = 0; i < flags.BACHDEP; ++i)
-            free(bach[i].coef);
-        free(bach);
-    }
-    if (flags.DEPTH > 0) {
-        for (i = 0; i < dim; i++) {
-            for (j = 0; j <= comb[i].list.n; j++)
+
+	V.dim = dim;
+	V.len = dim + F.n;
+/* get the short vectors */
+        V.n = SV->rows;
+        if ((V.v = (int**)malloc((V.n+1) * sizeof(int*))) == 0)
+			exit (2);
+        if ((V.v[0] = (int*)malloc(V.len * sizeof(int))) == 0)
+			exit (2);
+        /* tilman 9/1/97 changed these lines 
+        for(i=1;i<= V.n;i++)
+        {
+               V.v[i] = SV->array.SZ[i-1];
+        } to (next 5 lines): */
+        for(i=1;i<= V.n;i++)
+        {
+           V.v[i] = (int *) malloc((SV->rows+1) * sizeof(int));
+           for (j=0;j<SV->cols;j++){
+              V.v[i][j] = SV->array.SZ[i-1][j];
+           }
+        }
+
+/* the first nonzero entry of each vector is made positive and the maximal
+   entry of the vectors is determined */
+	max = 1;
+	for (i = 1; i <= V.n; ++i)
+	{
+		Vvi = V.v[i];
+		for (j = 0; j < dim  &&  Vvi[j] == 0; ++j);
+		if (j < dim  &&  Vvi[j] < 0)
+		{
+			for (k = j; k < dim; ++k)
+				Vvi[k] *= -1;
+		}
+		for (k = j; k < dim; ++k)
+		{
+			if (abs(Vvi[k]) > max)
+				max = abs(Vvi[k]);
+		}
+	}
+	if (max > MAXENTRY)
+/* there is an entry, which is bigger than MAXENTRY, which might cause overflow,
+   since the program doesn't use long integer arithmetic */
+	{
+		fprintf(stderr, "Error: Found entry %d in short vectors.\nTo avoid overflow, the entries should not exceed %d.\n", max, MAXENTRY);
+		exit (3);
+	}
+/* V.prime is a prime p, such that every entry x in the short vectors remains
+   unchanged under reduction mod p in symmetric form, i.e. -p/2 < x <= p/2 */
+	for (V.prime = 2*max + 1; isprime(V.prime) == 0; ++V.prime);
+/* sort the vectors and delete doublets */
+	sortvecs(&V);
+/* the norm-vector (i.e. the vector of the norms with respect to the different
+   invariant forms) of each vector must be equal to the norm-vector of one
+   of the vectors from the standard-base */
+	if ((norm.v = (int**)malloc((dim+1) * sizeof(int*))) == 0)
+		exit (2);
+	norm.n = dim;
+	norm.dim = F.n;
+	norm.len = F.n;
+	for (i = 1; i <= norm.n; ++i)
+	{
+/* norm.v[i] is the norm combination of the (i-1)-th base-vector */
+		if ((norm.v[i] = (int*)malloc(norm.dim * sizeof(int))) == 0)
+			exit (2);
+		for (k = 0; k < norm.dim; ++k)
+			norm.v[i][k] = F.A[k][i-1][i-1];
+	}
+	sortvecs(&norm);
+/* delete those vectors, which can not be the image of any of the standard-base
+   vectors */
+	checkvecs(&V, F, norm);
+	for (i = 1; i <= norm.n; ++i)
+		free(norm.v[i]);
+	free(norm.v);
+/* print the invariant forms, if output is in ASCII-format */
+/*********************************************
+		printf("#%d\n", F.n);
+		for (i = 0; i < F.n; ++i)
+			putform(F.A[i], dim);
+**********************************************/
+/* F.v[i][j] is the transposed of the product of the Gram-matrix F.A[i] with the
+   transposed of the vector v[j], hence the scalar product of v[j] and v[k] with
+   respect to the Gram-matrix F.A[i] can be computed as standard scalar product
+   of v[j] and F.v[i][k] */
+	if ((F.v = (int***)malloc(F.n * sizeof(int**))) == 0)
+		exit (2);
+/* the product of the maximal entry in the short vectors with the maximal entry
+   in F.v[i] should not exceed MAXNORM to avoid overflow */
+	max = MAXNORM / max;
+	for (i = 0; i < F.n; ++i)
+	{
+		FAi = F.A[i];
+		if ((F.v[i] = (int**)malloc((V.n+1) * sizeof(int*))) == 0)
+			exit (2);
+		Fvi = F.v[i];
+		for (j = 1; j <= V.n; ++j)
+		{
+			Vvj = V.v[j];
+			if ((Fvi[j] = (int*)malloc(dim * sizeof(int))) == 0)
+				exit (2);
+			Fvij = Fvi[j];
+			for (k = 0; k < dim; ++k)
+			{
+				Fvij[k] = sscp(FAi[k], Vvj, dim);
+				if (abs(Fvij[k]) > max)
+/* some entry in F.v[i] is too large */
+				{
+					fprintf(stderr, "Error: Found entry %d in F.v.\nTo avoid overflow, the entries should not exceed %d.\n", Fvij[k], max);
+					exit (3);
+				}
+			}
+		}
+	}
+/* fp.per is the order in which the images of the base-vectors are set */
+	if ((fp.per = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+/* fp.e[i] is the index in V.v of the i-th vector of the standard-base in the 
+   new order */
+	if ((fp.e = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+/* fp.diag is the diagonal of the fingerprint in the new order, fp.diag[i] is
+   an upper bound for the length of the orbit of the i-th base-vector under
+   the stabilizer of the preceding ones */
+	if ((fp.diag = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+/* compute the fingerprint */
+	fingerprint(&fp, F, V);
+        mach_perp_matrices(fp, P, Pbase, dim);
+        pointer_mat_quicksort(perp, 0, perp_no-1, dim, dim, pointer_lower_triangular_mat_comp);
+	if (flags.PRINT == 1)
+/* if the -P option is given, print the diagonal fp.diag and the number of short
+   vectors on AUTO.tmp */
+	{
+		outfile = fopen("AUTO.tmp", "a");
+		fprintf(outfile, "%d short vectors\n", 2*V.n);
+		fprintf(outfile, "fingerprint diagonal:\n");
+		for (i = 0; i < dim; ++i)
+			fprintf(outfile, " %2d", fp.diag[i]);
+		fprintf(outfile, "\n");
+		fclose(outfile);
+	}
+/* get the standard basis in the new order */
+	if ((vec = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+	for (i = 0; i < dim; ++i)
+	{
+		for (j = 0; j < dim; ++j)
+			vec[j] = 0;
+		vec[fp.per[i]] = 1;
+		fp.e[i] = numberof(vec, V);
+		if (abs(fp.e[i]) > V.n)
+/* the standard-base must occur in the set of short vectors, since Id is
+   certainly an automorphism */
+		{
+			fprintf(stderr, "Error: standard basis vector nr. %d not found\n", i);
+			exit (3);
+		}
+	}
+	free(vec);
+/* if the -D option is given, the scalar product combinations and the 
+   corresponding vector sums are computed for the standard-basis */
+	if (flags.DEPTH > 0)
+	{
+		if ((comb = (scpcomb*)malloc(dim * sizeof(scpcomb))) == 0)
+			exit (3);
+		for (i = 0; i < dim; ++i)
+		{
+/* compute the list of scalar product combinations and the corresponding
+   vector sums */
+			scpvecs(&comb[i].list, &sumveclist, i, fp.e, flags.DEPTH, V, F);
+/* compute a basis for the lattice that is generated by the vector sums and
+   a transformation matrix that expresses the basis in terms of the 
+   vector sums */
+			base(&comb[i], &sumvecbase, sumveclist, F.A[0], dim);
+			if (flags.PRINT == 1)
+/* if the -P option is given, print the rank of the lattice generated by the
+   vector sums on level i on AUTO.tmp */
+			{
+				outfile = fopen("AUTO.tmp", "a");
+				fprintf(outfile, "comb[%d].rank = %d\n", i, comb[i].rank);
+				fclose(outfile);
+			}
+/* compute the coefficients of the vector sums in terms of the basis */
+			coef(&comb[i], sumvecbase, sumveclist, F.A[0], dim);
+			for (j = 0; j <= comb[i].list.n; ++j)
+				free(sumveclist[j]);
+			free(sumveclist);
+/* compute the scalar products of the base-vectors */
+			scpforms(&comb[i], sumvecbase, F);
+			for (j = 0; j < comb[i].rank; ++j)
+				free(sumvecbase[j]);
+			free(sumvecbase);
+		}
+	}
+/* the Bacher-polynomials for the first BACHDEP base-vectors are computed,
+   if no scalar product was given as an argument, the scalar product is set
+   to 1/2 the norm of the base-vector (with respect to the first form) */
+	if (flags.BACH[0] == 1)
+	{
+		if ((bach = (bachpol*)malloc(flags.BACHDEP * sizeof(bachpol))) == 0)
+			exit (2);
+		for (i = 0; i < flags.BACHDEP; ++i)
+		{
+			if (flags.BACH[2] == 0)
+/* no scalar product was given as an option */
+				flags.BACHSCP = V.v[fp.e[i]][dim] / 2;
+/* compute the Bacher-polynomial */
+			bacher(&bach[i], fp.e[i], flags.BACHSCP, V, F.v[0]);
+			if (flags.PRINT == 1)
+/* if the -P option is given, print the Bacher-polynomial on AUTO.tmp */
+			{
+				outfile = fopen("AUTO.tmp", "a");
+				fprintf(outfile, "Bacher-polynomial of base vector fp.e[%d]:\n", i);
+				fputbach(outfile, bach[i]);
+				fclose(outfile);
+			}
+		}
+	}
+/* set up the group: the generators in G.g[i] are matrices that fix the
+   first i base-vectors but do not fix fp.e[i] */
+	if ((G.g = (int****)malloc(dim * sizeof(int***))) == 0)
+		exit (2);
+/* G.ng is the number of generators in G.g[i] */
+	if ((G.ng = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+/* the first G.nsg[i] generators in G.g[i] are obtained as stabilizer elements
+   and are not necessary to generate the group */
+	if ((G.nsg = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+/* G.ord[i] is the orbit length of fp.e[i] under the generators in 
+   G.g[i] ... G.g[dim-1] */
+	if ((G.ord = (int*)malloc(dim * sizeof(int))) == 0)
+		exit (2);
+	for (i = 0; i < dim; ++i)
+	{
+		if ((G.g[i] = (int***)malloc(1 * sizeof(int**))) == 0)
+			exit (2);
+		G.ng[i] = 0;
+		G.nsg[i] = 0;
+	}
+	G.dim = dim;
+	if ((G.g[0][0] = (int**)malloc(dim * sizeof(int*))) == 0)
+		exit (2);
+/* -Id is always an automorphism */
+	for (i = 0; i < dim; ++i)
+	{
+		if ((G.g[0][0][i] = (int*)malloc(dim * sizeof(int))) == 0)
+			exit (2);
+		for (j = 0; j < dim; ++j)
+			G.g[0][0][i][j] = 0;
+		G.g[0][0][i][i] = -1;
+		G.ng[0] = 1;
+	}
+/* fill in the generators which were given as input */
+	for (i = 0; i < nH; ++i)
+	{
+		for (j = 0; j < dim  &&  operate(fp.e[j], H[i], V) == fp.e[j]; ++j);
+		if (j < dim)
+/* the generator is not Id and fixes fp.e[0],...,fp.e[j-1] but not fp.e[j] */
+		{
+			++G.ng[j];
+			if ((G.g[j] = (int***)realloc(G.g[j], G.ng[j] * sizeof(int**))) == 0)
+				exit (2);
+			if ((G.g[j][G.ng[j]-1] = (int**)malloc(dim * sizeof(int*))) == 0)
+				exit (2);
+			for (k = 0; k < dim; ++k)
+			{
+				if ((G.g[j][G.ng[j]-1][k] = (int*)malloc(dim * sizeof(int))) == 0)
+					exit (2);
+				for (l = 0; l < dim; ++l)
+					G.g[j][G.ng[j]-1][k][l] = H[i][k][l];
+			}
+		}
+		for (k = 0; k < dim; ++k)
+			free(H[i][k]);
+		free(H[i]);
+	}
+	if (nH > 0)
+		free(H);
+	nH = 0;
+	for (i = 0; i < dim; ++i)
+		nH += G.ng[i];
+	if ((H = (int***)malloc(nH * sizeof(int**))) == 0)
+		exit (2);
+/* calculate the orbit lengths under the automorphisms known so far */
+	for (i = 0; i < dim; ++i)
+	{
+		if (G.ng[i] > 0)
+		{
+			nH = 0;
+			for (j = i; j < dim; ++j)
+			{
+				for (k = 0; k < G.ng[j]; ++k)
+				{
+					H[nH] = G.g[j][k];
+					++nH;
+				}
+			}
+			G.ord[i] = orbitlen(fp.e[i], fp.diag[i], H, nH, V);
+		}
+		else
+			G.ord[i] = 1;
+	}
+	free(H);
+/* compute the full automorphism group */
+	autom(&G, V, F, fp, comb, bach, flags);
+/* print the generators of the group, which are necessary for generating */
+	B = putgens(G, flags);
+	n = 0;
+	for (i = flags.STAB; i < dim; ++i)
+	{
+		if (G.ord[i] > 1)
+			++n;
+	}
+/* print a base to AUTO.tmp if the print-flag is set */
+	if (flags.PRINT == 1)
+	{
+		outfile = fopen("AUTO.tmp", "a");
+		fprintf(outfile, "%dx%d\n", n, dim);
+		for (i = flags.STAB; i < dim; ++i)
+		{
+			if (G.ord[i] > 1)
+			{
+				for (j = 0; j < dim; ++j)
+					fprintf(outfile, " %d", V.v[fp.e[i]][j]);
+				fprintf(outfile, "\n");
+			}
+		}
+		fclose(outfile);
+	}
+/* print the order of the group */
+	putord(G, flags, B);
+
+
+	if (flags.BACH[0] == 1)
+	{
+		for (i = 0; i < flags.BACHDEP; ++i)
+                   free(bach[i].coef);
+                free(bach);
+        }
+	if (flags.DEPTH > 0)
+	{
+            for(i=0;i<dim;i++)
+            {
+              for(j=0;j<=comb[i].list.n;j++)
                 free(comb[i].coef[j]);
-            free(comb[i].coef);
-            for (j = 0; j <= comb[i].list.n; j++)
+              free(comb[i].coef);
+              for(j=0;j<=comb[i].list.n;j++)
                 free(comb[i].list.v[j]);
-            free(comb[i].list.v);
-            for (j = 0; j < comb[i].rank; j++)
+              free(comb[i].list.v);
+              for(j=0;j<comb[i].rank;j++)
                 free(comb[i].trans[j]);
-            free(comb[i].trans);
-            for (j = 0; j < F.n; j++) {
-                for (k = 0; k < comb[i].rank; k++)
+              free(comb[i].trans);
+              for(j=0;j<F.n;j++)
+              {
+                 for(k=0;k<comb[i].rank;k++)
                     free(comb[i].F[j][k]);
-                free(comb[i].F[j]);
+                 free(comb[i].F[j]);
+              }
+              free(comb[i].F);
             }
-            free(comb[i].F);
+            free(comb);
         }
-        free(comb);
-    }
-    for (i = 0; i < F.n; i++) {
-        for (j = 1; j <= V.n; j++)
+        for(i=0;i<F.n;i++)
+        {
+          for(j=1;j<=V.n;j++)
             free(F.v[i][j]);
-        free(F.v[i]);
-        for (j = 0; j < dim; j++)
+          free(F.v[i]);
+          for(j=0;j<dim;j++)
             free(F.A[i][j]);
-        free(F.A[i]);
-    }
-    free(F.A);
-    free(F.v);
-
-    /* inserted the next 3 lines 9/1/97 tilman */
-    for (j = 0; j <= V.n; j++) {
-        free(V.v[j]);
-    }
-
-    free(V.v);
-    free_perp_matrices(dim);
-    free(fp.diag);
-    free(fp.per);
-    free(fp.e);
-    for (i = 0; i < dim; i++) {
-        for (j = 0; j < G.ng[i]; j++) {
-            for (k = 0; k < dim; k++)
-                free(G.g[i][j][k]);
-            free(G.g[i][j]);
+          free(F.A[i]);
         }
-        free(G.g[i]);
-    }
-    free(G.g);
-    free(G.ord);
-    free(G.ng);
-    free(G.nsg);
+        free(F.A); free(F.v);
 
-    return (B);
+        /* inserted the next 3 lines 9/1/97 tilman */
+        for (j=0;j<=V.n;j++){
+           free(V.v[j]);
+        }
+
+        free(V.v);
+        free_perp_matrices(dim);
+        free(fp.diag); free(fp.per); free(fp.e);
+        for(i=0;i<dim;i++)
+        {
+           for(j=0;j<G.ng[i];j++)
+           {
+             for(k=0;k<dim;k++)
+               free(G.g[i][j][k]);
+             free(G.g[i][j]);
+           }
+           free(G.g[i]);
+        }
+        free(G.g); free(G.ord); free(G.ng); free(G.nsg);
+
+        return(B);
 }

--- a/functions/Autgrp/autgrp.c
+++ b/functions/Autgrp/autgrp.c
@@ -1,7 +1,7 @@
 /*****	Main program for the automorphism program AUTO	*****/
+#include "sort.h"
 #include "typedef.h"
 #include "types.h"
-#include "sort.h"
 
 /**************************************************************************\
 @---------------------------------------------------------------------------
@@ -12,13 +12,13 @@
 @
 \**************************************************************************/
 
-int normal_option = 0;
-int perp_no = 0;
-int ***perp = 0;
-int perpdim = 0;
-int ***perpbase = 0;
-int ***perpprod = 0;
-int *perpvec = 0;
+int     normal_option = 0;
+int     perp_no = 0;
+int *** perp = 0;
+int     perpdim = 0;
+int *** perpbase = 0;
+int *** perpprod = 0;
+int *   perpvec = 0;
 
 /*************************************************************************\
 @-------------------------------------------------------------------------
@@ -37,10 +37,11 @@ int *perpvec = 0;
 @ matrix_TYP	**Erz:		if already element of G are known,
 @				they can be used for calculating generators
 @				for the whole group.
-@				The matrices of known elements can be given 
+@				The matrices of known elements can be given
 @				to the function by the pointer 'Erz'.
 @ int		Erzanz:		The number of matrices given in 'Erz"
-@ matrix_TYP	*SV:		The rows of the matrix 'SV' must be the vectors
+@ matrix_TYP	*SV:		The rows of the matrix 'SV' must be the
+vectors
 @				x in Z^n with x * F[0] * x^{tr} <= m, where
 @				m is the maximal diagonal entry of the Matrix
 @				F[0]
@@ -57,10 +58,10 @@ int *perpvec = 0;
 @		will be calculated.
 @ options[2]:	If options[2] = 1, additional output is written to the
 @               file AUTO.tmp
-@ options[3]:   If options[3] = 1, Bacher polynomials are used. 
+@ options[3]:   If options[3] = 1, Bacher polynomials are used.
 @		If options[3] = 2, Bacher polynomial are used up to a deepth
 @		                   specified in options[4].
-@		If options[3] = 3, Bacher polynomials are used, using 
+@		If options[3] = 3, Bacher polynomials are used, using
 @		                   combinations of vectors having the scalar
 @		                   product specified in options[5]
 @		options[3] = 4 is the combination of options[3] = 2 and
@@ -74,487 +75,477 @@ int *perpvec = 0;
 \*************************************************************************/
 
 
-bravais_TYP *
-autgrp (matrix_TYP **Fo, int Foanz, matrix_TYP *SV, matrix_TYP **Erz, int Erzanz, int *options)
+bravais_TYP * autgrp(matrix_TYP ** Fo,
+                     int           Foanz,
+                     matrix_TYP *  SV,
+                     matrix_TYP ** Erz,
+                     int           Erzanz,
+                     int *         options)
 {
-	FILE		*outfile;
-	bachpol		*bach = 0;
-	flagstruct	flags;
-	scpcomb		*comb = 0;
-	group		G;
-	invar		F;
-	veclist		V, norm;
-	fpstruct	fp;
-	int		dim, max, fail, *vec;
-	int		***H = 0, nH = 0, ngen, **sumveclist, **sumvecbase;
-	int		i, j, k, l, n, *Vvi, *Vvj, **Fvi, *Fvij, **FAi;
-        bravais_TYP *B;
+    FILE *        outfile;
+    bachpol *     bach = 0;
+    flagstruct    flags;
+    scpcomb *     comb = 0;
+    group         G;
+    invar         F;
+    veclist       V, norm;
+    fpstruct      fp;
+    int           dim, max, fail, *vec;
+    int ***       H = 0, nH = 0, ngen, **sumveclist, **sumvecbase;
+    int           i, j, k, l, n, *Vvi, *Vvj, **Fvi, *Fvij, **FAi;
+    bravais_TYP * B;
 
-   normal_option = FALSE;
-/* get the flags from the command line */
-	getflags(&flags, options);
-   if(Erzanz > 0)
-     flags.GEN = 1;
-   else
-     flags.GEN = 0;
-/* F.n is the number of invariant forms */
-	F.n = Foanz;
-	if ((F.A = (int***)malloc(F.n * sizeof(int**))) == 0)
-		exit (2);
-/* read the invariant forms */
-        F.dim = Fo[0]->cols;
-	dim = F.dim;
-        for(i=0;i<F.n;i++)
-        {
-           if(Fo[i]->cols != F.dim || Fo[i]->rows != F.dim)
-           {
-              printf("forms in autgrp have different dimension\n");
-              exit(3);
-           }
+    normal_option = FALSE;
+    /* get the flags from the command line */
+    getflags(&flags, options);
+    if (Erzanz > 0)
+        flags.GEN = 1;
+    else
+        flags.GEN = 0;
+    /* F.n is the number of invariant forms */
+    F.n = Foanz;
+    if ((F.A = (int ***)malloc(F.n * sizeof(int **))) == 0)
+        exit(2);
+    /* read the invariant forms */
+    F.dim = Fo[0]->cols;
+    dim = F.dim;
+    for (i = 0; i < F.n; i++) {
+        if (Fo[i]->cols != F.dim || Fo[i]->rows != F.dim) {
+            printf("forms in autgrp have different dimension\n");
+            exit(3);
         }
-        for(i=0;i<F.n;i++)
-        {
-	  if ((F.A[i] = (int**)malloc(dim * sizeof(int*))) == 0)
-		exit (2);
-          for(j=0;j<F.dim;j++)
-          {
-	    if ((F.A[i][j] = (int*)malloc(dim * sizeof(int))) == 0)
-		  exit (2);
-            for(k=0;k<F.dim;k++)
-              F.A[i][j][k] = Fo[i]->array.SZ[j][k];
-          }
+    }
+    for (i = 0; i < F.n; i++) {
+        if ((F.A[i] = (int **)malloc(dim * sizeof(int *))) == 0)
+            exit(2);
+        for (j = 0; j < F.dim; j++) {
+            if ((F.A[i][j] = (int *)malloc(dim * sizeof(int))) == 0)
+                exit(2);
+            for (k = 0; k < F.dim; k++)
+                F.A[i][j][k] = Fo[i]->array.SZ[j][k];
         }
-	if (flags.GEN == 1)
-/* some automorphisms are already known */
-	{
-		ngen = Erzanz;
-		if ((H = (int***)malloc(ngen * sizeof(int**))) == 0)
-			exit (2);
-		nH = 0;
-		fail = 0;
-                for(i=0;i<ngen;i++)
-                {
-                  if(Erz[i]->cols != dim || Erz[i]->rows != dim)
-                  {
-                    printf("Elements 'Erz' have wrong dimension\n");
-                    exit(3);
-                  }
-                }
-                i = 0;
-		while (nH+fail < ngen)
-		{
-		    if ((H[nH] = (int**)malloc(dim * sizeof(int*))) == 0)
-			exit (2);
-                    for(j=0;j<dim;j++)
-                    {
-		      if ((H[nH][j] = (int*)malloc(dim * sizeof(int))) == 0)
-		  	exit (2);
-                      for(k=0;k<dim;k++)
-                        H[nH][j][k] = Erz[i]->array.SZ[k][j];
-                    }
-/* check whether the matrix is really an automorphism, i.e. fixes the forms */
-			if (checkgen(H[nH], F) == 0)
-/* the matrix is not an automorphism */
-			{
-				++fail;
-				for (j = 0; j < dim; ++j)
-					free(H[nH][j]);
-                                free(H[nH]);
-			}
-			else
-/* the matrix fixes all forms in F */
-				++nH;
-                    i++;
-		}
-	}
-	else
-		nH = 0;
-
-
-
-	V.dim = dim;
-	V.len = dim + F.n;
-/* get the short vectors */
-        V.n = SV->rows;
-        if ((V.v = (int**)malloc((V.n+1) * sizeof(int*))) == 0)
-			exit (2);
-        for(i=0;i<=V.n;i++)
-        {
-          if ((V.v[i] = (int*)malloc(V.len * sizeof(int))) == 0)
-			exit (2);
-        }
-        for(i=1;i<= V.n;i++)
-        {
-            for(j=0;j<=dim;j++)
-               V.v[i][j] = SV->array.SZ[i-1][j];
-        }
-/* the first nonzero entry of each vector is made positive and the maximal
-   entry of the vectors is determined */
-	max = 1;
-	for (i = 1; i <= V.n; ++i)
-	{
-		Vvi = V.v[i];
-		for (j = 0; j < dim  &&  Vvi[j] == 0; ++j);
-		if (j < dim  &&  Vvi[j] < 0)
-		{
-			for (k = j; k < dim; ++k)
-				Vvi[k] *= -1;
-		}
-		for (k = j; k < dim; ++k)
-		{
-			if (abs(Vvi[k]) > max)
-				max = abs(Vvi[k]);
-		}
-	}
-	if (max > MAXENTRY)
-/* there is an entry, which is bigger than MAXENTRY, which might cause overflow,
-   since the program doesn't use long integer arithmetic */
-	{
-		fprintf(stderr, "Error: Found entry %d in short vectors.\nTo avoid overflow, the entries should not exceed %d.\n", max, MAXENTRY);
-		exit (3);
-	}
-/* V.prime is a prime p, such that every entry x in the short vectors remains
-   unchanged under reduction mod p in symmetric form, i.e. -p/2 < x <= p/2 */
-	for (V.prime = 2*max + 1; isprime(V.prime) == 0; ++V.prime);
-/* sort the vectors and delete doublets */
-	sortvecs(&V);
-/* the norm-vector (i.e. the vector of the norms with respect to the different
-   invariant forms) of each vector must be equal to the norm-vector of one
-   of the vectors from the standard-base */
-	if ((norm.v = (int**)malloc((dim+1) * sizeof(int*))) == 0)
-		exit (2);
-	norm.n = dim;
-	norm.dim = F.n;
-	norm.len = F.n;
-	for (i = 1; i <= norm.n; ++i)
-	{
-/* norm.v[i] is the norm combination of the (i-1)-th base-vector */
-		if ((norm.v[i] = (int*)malloc(norm.dim * sizeof(int))) == 0)
-			exit (2);
-		for (k = 0; k < norm.dim; ++k)
-			norm.v[i][k] = F.A[k][i-1][i-1];
-	}
-	sortvecs(&norm);
-/* delete those vectors, which can not be the image of any of the standard-base
-   vectors */
-	checkvecs(&V, F, norm);
-	for (i = 1; i <= norm.n; ++i)
-		free(norm.v[i]);
-	free(norm.v);
-/* print the invariant forms, if output is in ASCII-format */
-/*********************************************
-		printf("#%d\n", F.n);
-		for (i = 0; i < F.n; ++i)
-			putform(F.A[i], dim);
-**********************************************/
-/* F.v[i][j] is the transposed of the product of the Gram-matrix F.A[i] with the
-   transposed of the vector v[j], hence the scalar product of v[j] and v[k] with
-   respect to the Gram-matrix F.A[i] can be computed as standard scalar product
-   of v[j] and F.v[i][k] */
-	if ((F.v = (int***)malloc(F.n * sizeof(int**))) == 0)
-		exit (2);
-/* the product of the maximal entry in the short vectors with the maximal entry
-   in F.v[i] should not exceed MAXNORM to avoid overflow */
-	max = MAXNORM / max;
-	for (i = 0; i < F.n; ++i)
-	{
-		FAi = F.A[i];
-		if ((F.v[i] = (int**)malloc((V.n+1) * sizeof(int*))) == 0)
-			exit (2);
-		Fvi = F.v[i];
-		for (j = 1; j <= V.n; ++j)
-		{
-			Vvj = V.v[j];
-			if ((Fvi[j] = (int*)malloc(dim * sizeof(int))) == 0)
-				exit (2);
-			Fvij = Fvi[j];
-			for (k = 0; k < dim; ++k)
-			{
-				Fvij[k] = sscp(FAi[k], Vvj, dim);
-				if (abs(Fvij[k]) > max)
-/* some entry in F.v[i] is too large */
-				{
-					fprintf(stderr, "Error: Found entry %d in F.v.\nTo avoid overflow, the entries should not exceed %d.\n", Fvij[k], max);
-					exit (3);
-				}
-			}
-		}
-	}
-/* fp.per is the order in which the images of the base-vectors are set */
-	if ((fp.per = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-/* fp.e[i] is the index in V.v of the i-th vector of the standard-base in the 
-   new order */
-	if ((fp.e = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-/* fp.diag is the diagonal of the fingerprint in the new order, fp.diag[i] is
-   an upper bound for the length of the orbit of the i-th base-vector under
-   the stabilizer of the preceding ones */
-	if ((fp.diag = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-/* compute the fingerprint */
-	fingerprint(&fp, F, V);
-	if (flags.PRINT == 1)
-/* if the -P option is given, print the diagonal fp.diag and the number of short
-   vectors on AUTO.tmp */
-	{
-		outfile = fopen("AUTO.tmp", "a");
-		fprintf(outfile, "%d short vectors\n", 2*V.n);
-		fprintf(outfile, "fingerprint diagonal:\n");
-		for (i = 0; i < dim; ++i)
-			fprintf(outfile, " %2d", fp.diag[i]);
-		fprintf(outfile, "\n");
-		fclose(outfile);
-	}
-/* get the standard basis in the new order */
-	if ((vec = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-	for (i = 0; i < dim; ++i)
-	{
-		for (j = 0; j < dim; ++j)
-			vec[j] = 0;
-		vec[fp.per[i]] = 1;
-		fp.e[i] = numberof(vec, V);
-		if (abs(fp.e[i]) > V.n)
-/* the standard-base must occur in the set of short vectors, since Id is
-   certainly an automorphism */
-		{
-			fprintf(stderr, "Error: standard basis vector nr. %d not found\n", i);
-			exit (2);
-		}
-	}
-	free(vec);
-/* if the -D option is given, the scalar product combinations and the 
-   corresponding vector sums are computed for the standard-basis */
-	if (flags.DEPTH > 0)
-	{
-		if ((comb = (scpcomb*)malloc(dim * sizeof(scpcomb))) == 0)
-			exit (2);
-		for (i = 0; i < dim; ++i)
-		{
-/* compute the list of scalar product combinations and the corresponding
-   vector sums */
-			scpvecs(&comb[i].list, &sumveclist, i, fp.e, flags.DEPTH, V, F);
-/* compute a basis for the lattice that is generated by the vector sums and
-   a transformation matrix that expresses the basis in terms of the 
-   vector sums */
-			base(&comb[i], &sumvecbase, sumveclist, F.A[0], dim);
-			if (flags.PRINT == 1)
-/* if the -P option is given, print the rank of the lattice generated by the
-   vector sums on level i on AUTO.tmp */
-			{
-				outfile = fopen("AUTO.tmp", "a");
-				fprintf(outfile, "comb[%d].rank = %d\n", i, comb[i].rank);
-				fclose(outfile);
-			}
-/* compute the coefficients of the vector sums in terms of the basis */
-			coef(&comb[i], sumvecbase, sumveclist, F.A[0], dim);
-			for (j = 0; j <= comb[i].list.n; ++j)
-				free(sumveclist[j]);
-			free(sumveclist);
-/* compute the scalar products of the base-vectors */
-			scpforms(&comb[i], sumvecbase, F);
-			for (j = 0; j < comb[i].rank; ++j)
-				free(sumvecbase[j]);
-			free(sumvecbase);
-		}
-	}
-/* the Bacher-polynomials for the first BACHDEP base-vectors are computed,
-   if no scalar product was given as an argument, the scalar product is set
-   to 1/2 the norm of the base-vector (with respect to the first form) */
-	if (flags.BACH[0] == 1)
-	{
-		if ((bach = (bachpol*)malloc(flags.BACHDEP * sizeof(bachpol))) == 0)
-			exit (2);
-		for (i = 0; i < flags.BACHDEP; ++i)
-		{
-			if (flags.BACH[2] == 0)
-/* no scalar product was given as an option */
-				flags.BACHSCP = V.v[fp.e[i]][dim] / 2;
-/* compute the Bacher-polynomial */
-			bacher(&bach[i], fp.e[i], flags.BACHSCP, V, F.v[0]);
-			if (flags.PRINT == 1)
-/* if the -P option is given, print the Bacher-polynomial on AUTO.tmp */
-			{
-				outfile = fopen("AUTO.tmp", "a");
-				fprintf(outfile, "Bacher-polynomial of base vector fp.e[%d]:\n", i);
-				fputbach(outfile, bach[i]);
-				fclose(outfile);
-			}
-		}
-	}
-/* set up the group: the generators in G.g[i] are matrices that fix the
-   first i base-vectors but do not fix fp.e[i] */
-	if ((G.g = (int****)malloc(dim * sizeof(int***))) == 0)
-		exit (2);
-/* G.ng is the number of generators in G.g[i] */
-	if ((G.ng = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-/* the first G.nsg[i] generators in G.g[i] are obtained as stabilizer elements
-   and are not necessary to generate the group */
-	if ((G.nsg = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-/* G.ord[i] is the orbit length of fp.e[i] under the generators in 
-   G.g[i] ... G.g[dim-1] */
-	if ((G.ord = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-	for (i = 0; i < dim; ++i)
-	{
-		if ((G.g[i] = (int***)malloc(1 * sizeof(int**))) == 0)
-			exit (2);
-		G.ng[i] = 0;
-		G.nsg[i] = 0;
-	}
-	G.dim = dim;
-	if ((G.g[0][0] = (int**)malloc(dim * sizeof(int*))) == 0)
-		exit (2);
-/* -Id is always an automorphism */
-	for (i = 0; i < dim; ++i)
-	{
-		if ((G.g[0][0][i] = (int*)malloc(dim * sizeof(int))) == 0)
-			exit (2);
-		for (j = 0; j < dim; ++j)
-			G.g[0][0][i][j] = 0;
-		G.g[0][0][i][i] = -1;
-		G.ng[0] = 1;
-	}
-/* fill in the generators which were given as input */
-	for (i = 0; i < nH; ++i)
-	{
-		for (j = 0; j < dim  &&  operate(fp.e[j], H[i], V) == fp.e[j]; ++j);
-		if (j < dim)
-/* the generator is not Id and fixes fp.e[0],...,fp.e[j-1] but not fp.e[j] */
-		{
-			++G.ng[j];
-			if ((G.g[j] = (int***)realloc(G.g[j], G.ng[j] * sizeof(int**))) == 0)
-				exit (2);
-			if ((G.g[j][G.ng[j]-1] = (int**)malloc(dim * sizeof(int*))) == 0)
-				exit (2);
-			for (k = 0; k < dim; ++k)
-			{
-				if ((G.g[j][G.ng[j]-1][k] = (int*)malloc(dim * sizeof(int))) == 0)
-					exit (2);
-				for (l = 0; l < dim; ++l)
-					G.g[j][G.ng[j]-1][k][l] = H[i][k][l];
-			}
-		}
-		for (k = 0; k < dim; ++k)
-			free(H[i][k]);
-		free(H[i]);
-	}
-	if (nH > 0)
-		free(H);
-	nH = 0;
-	for (i = 0; i < dim; ++i)
-		nH += G.ng[i];
-	if ((H = (int***)malloc(nH * sizeof(int**))) == 0)
-		exit (2);
-/* calculate the orbit lengths under the automorphisms known so far */
-	for (i = 0; i < dim; ++i)
-	{
-		if (G.ng[i] > 0)
-		{
-			nH = 0;
-			for (j = i; j < dim; ++j)
-			{
-				for (k = 0; k < G.ng[j]; ++k)
-				{
-					H[nH] = G.g[j][k];
-					++nH;
-				}
-			}
-			G.ord[i] = orbitlen(fp.e[i], fp.diag[i], H, nH, V);
-		}
-		else
-			G.ord[i] = 1;
-	}
-	free(H);
-/* compute the full automorphism group */
-	autom(&G, V, F, fp, comb, bach, flags);
-/* print the generators of the group, which are necessary for generating */
-	B = putgens(G, flags);
-	n = 0;
-	for (i = flags.STAB; i < dim; ++i)
-	{
-		if (G.ord[i] > 1)
-			++n;
-	}
-/* print a base to AUTO.tmp if the print-flag is set */
-	if (flags.PRINT == 1)
-	{
-		outfile = fopen("AUTO.tmp", "a");
-		fprintf(outfile, "%dx%d\n", n, dim);
-		for (i = flags.STAB; i < dim; ++i)
-		{
-			if (G.ord[i] > 1)
-			{
-				for (j = 0; j < dim; ++j)
-					fprintf(outfile, " %d", V.v[fp.e[i]][j]);
-				fprintf(outfile, "\n");
-			}
-		}
-		fclose(outfile);
-	}
-/* print the order of the group */
-	putord(G, flags, B);
-
-
-	if (flags.BACH[0] == 1)
-	{
-		for (i = 0; i < flags.BACHDEP; ++i)
-                   free(bach[i].coef);
-                free(bach);
-        }
-	if (flags.DEPTH > 0)
-	{
-            for(i=0;i<dim;i++)
-            {
-              for(j=0;j<=comb[i].list.n;j++)
-                free(comb[i].coef[j]);
-              free(comb[i].coef);
-              for(j=0;j<=comb[i].list.n;j++)
-                free(comb[i].list.v[j]);
-              free(comb[i].list.v);
-              for(j=0;j<comb[i].rank;j++)
-                free(comb[i].trans[j]);
-              free(comb[i].trans);
-              for(j=0;j<F.n;j++)
-              {
-                 for(k=0;k<comb[i].rank;k++)
-                    free(comb[i].F[j][k]);
-                 free(comb[i].F[j]);
-              }
-              free(comb[i].F);
+    }
+    if (flags.GEN == 1)
+    /* some automorphisms are already known */
+    {
+        ngen = Erzanz;
+        if ((H = (int ***)malloc(ngen * sizeof(int **))) == 0)
+            exit(2);
+        nH = 0;
+        fail = 0;
+        for (i = 0; i < ngen; i++) {
+            if (Erz[i]->cols != dim || Erz[i]->rows != dim) {
+                printf("Elements 'Erz' have wrong dimension\n");
+                exit(3);
             }
-            free(comb);
         }
-        for(i=0;i<F.n;i++)
-        {
-          for(j=1;j<=V.n;j++)
-            free(F.v[i][j]);
-          free(F.v[i]);
-          for(j=0;j<dim;j++)
-            free(F.A[i][j]);
-          free(F.A[i]);
+        i = 0;
+        while (nH + fail < ngen) {
+            if ((H[nH] = (int **)malloc(dim * sizeof(int *))) == 0)
+                exit(2);
+            for (j = 0; j < dim; j++) {
+                if ((H[nH][j] = (int *)malloc(dim * sizeof(int))) == 0)
+                    exit(2);
+                for (k = 0; k < dim; k++)
+                    H[nH][j][k] = Erz[i]->array.SZ[k][j];
+            }
+            /* check whether the matrix is really an automorphism, i.e. fixes
+             * the forms */
+            if (checkgen(H[nH], F) == 0)
+            /* the matrix is not an automorphism */
+            {
+                ++fail;
+                for (j = 0; j < dim; ++j)
+                    free(H[nH][j]);
+                free(H[nH]);
+            }
+            else
+                /* the matrix fixes all forms in F */
+                ++nH;
+            i++;
         }
-        free(F.A); free(F.v);
-        for(i=0;i<=V.n;i++)
-          free(V.v[i]);
-        free(V.v);
-        free(fp.diag); free(fp.per); free(fp.e);
-        for(i=0;i<dim;i++)
-        {
-           for(j=0;j<G.ng[i];j++)
-           {
-             for(k=0;k<dim;k++)
-               free(G.g[i][j][k]);
-             free(G.g[i][j]);
-           }
-           free(G.g[i]);
-        }
-        free(G.g); free(G.ord); free(G.ng); free(G.nsg);
+    }
+    else
+        nH = 0;
 
-        return(B);
+
+    V.dim = dim;
+    V.len = dim + F.n;
+    /* get the short vectors */
+    V.n = SV->rows;
+    if ((V.v = (int **)malloc((V.n + 1) * sizeof(int *))) == 0)
+        exit(2);
+    for (i = 0; i <= V.n; i++) {
+        if ((V.v[i] = (int *)malloc(V.len * sizeof(int))) == 0)
+            exit(2);
+    }
+    for (i = 1; i <= V.n; i++) {
+        for (j = 0; j <= dim; j++)
+            V.v[i][j] = SV->array.SZ[i - 1][j];
+    }
+    /* the first nonzero entry of each vector is made positive and the maximal
+       entry of the vectors is determined */
+    max = 1;
+    for (i = 1; i <= V.n; ++i) {
+        Vvi = V.v[i];
+        for (j = 0; j < dim && Vvi[j] == 0; ++j)
+            ;
+        if (j < dim && Vvi[j] < 0) {
+            for (k = j; k < dim; ++k)
+                Vvi[k] *= -1;
+        }
+        for (k = j; k < dim; ++k) {
+            if (abs(Vvi[k]) > max)
+                max = abs(Vvi[k]);
+        }
+    }
+    if (max > MAXENTRY)
+    /* there is an entry, which is bigger than MAXENTRY, which might cause
+       overflow, since the program doesn't use long integer arithmetic */
+    {
+        fprintf(stderr,
+                "Error: Found entry %d in short vectors.\nTo avoid overflow, "
+                "the entries should not exceed %d.\n",
+                max, MAXENTRY);
+        exit(3);
+    }
+    /* V.prime is a prime p, such that every entry x in the short vectors
+       remains
+       unchanged under reduction mod p in symmetric form, i.e. -p/2 < x <= p/2
+     */
+    for (V.prime = 2 * max + 1; isprime(V.prime) == 0; ++V.prime)
+        ;
+    /* sort the vectors and delete doublets */
+    sortvecs(&V);
+    /* the norm-vector (i.e. the vector of the norms with respect to the
+       different invariant forms) of each vector must be equal to the
+       norm-vector of one of the vectors from the standard-base */
+    if ((norm.v = (int **)malloc((dim + 1) * sizeof(int *))) == 0)
+        exit(2);
+    norm.n = dim;
+    norm.dim = F.n;
+    norm.len = F.n;
+    for (i = 1; i <= norm.n; ++i) {
+        /* norm.v[i] is the norm combination of the (i-1)-th base-vector */
+        if ((norm.v[i] = (int *)malloc(norm.dim * sizeof(int))) == 0)
+            exit(2);
+        for (k = 0; k < norm.dim; ++k)
+            norm.v[i][k] = F.A[k][i - 1][i - 1];
+    }
+    sortvecs(&norm);
+    /* delete those vectors, which can not be the image of any of the
+       standard-base vectors */
+    checkvecs(&V, F, norm);
+    for (i = 1; i <= norm.n; ++i)
+        free(norm.v[i]);
+    free(norm.v);
+    /* print the invariant forms, if output is in ASCII-format */
+    /*********************************************
+                    printf("#%d\n", F.n);
+                    for (i = 0; i < F.n; ++i)
+                            putform(F.A[i], dim);
+    **********************************************/
+    /* F.v[i][j] is the transposed of the product of the Gram-matrix F.A[i]
+       with the transposed of the vector v[j], hence the scalar product of
+       v[j] and v[k] with respect to the Gram-matrix F.A[i] can be computed as
+       standard scalar product of v[j] and F.v[i][k] */
+    if ((F.v = (int ***)malloc(F.n * sizeof(int **))) == 0)
+        exit(2);
+    /* the product of the maximal entry in the short vectors with the maximal
+       entry in F.v[i] should not exceed MAXNORM to avoid overflow */
+    max = MAXNORM / max;
+    for (i = 0; i < F.n; ++i) {
+        FAi = F.A[i];
+        if ((F.v[i] = (int **)malloc((V.n + 1) * sizeof(int *))) == 0)
+            exit(2);
+        Fvi = F.v[i];
+        for (j = 1; j <= V.n; ++j) {
+            Vvj = V.v[j];
+            if ((Fvi[j] = (int *)malloc(dim * sizeof(int))) == 0)
+                exit(2);
+            Fvij = Fvi[j];
+            for (k = 0; k < dim; ++k) {
+                Fvij[k] = sscp(FAi[k], Vvj, dim);
+                if (abs(Fvij[k]) > max)
+                /* some entry in F.v[i] is too large */
+                {
+                    fprintf(stderr,
+                            "Error: Found entry %d in F.v.\nTo avoid "
+                            "overflow, the entries should not exceed %d.\n",
+                            Fvij[k], max);
+                    exit(3);
+                }
+            }
+        }
+    }
+    /* fp.per is the order in which the images of the base-vectors are set */
+    if ((fp.per = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    /* fp.e[i] is the index in V.v of the i-th vector of the standard-base in
+       the new order */
+    if ((fp.e = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    /* fp.diag is the diagonal of the fingerprint in the new order, fp.diag[i]
+       is an upper bound for the length of the orbit of the i-th base-vector
+       under the stabilizer of the preceding ones */
+    if ((fp.diag = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    /* compute the fingerprint */
+    fingerprint(&fp, F, V);
+    if (flags.PRINT == 1)
+    /* if the -P option is given, print the diagonal fp.diag and the number of
+       short vectors on AUTO.tmp */
+    {
+        outfile = fopen("AUTO.tmp", "a");
+        fprintf(outfile, "%d short vectors\n", 2 * V.n);
+        fprintf(outfile, "fingerprint diagonal:\n");
+        for (i = 0; i < dim; ++i)
+            fprintf(outfile, " %2d", fp.diag[i]);
+        fprintf(outfile, "\n");
+        fclose(outfile);
+    }
+    /* get the standard basis in the new order */
+    if ((vec = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    for (i = 0; i < dim; ++i) {
+        for (j = 0; j < dim; ++j)
+            vec[j] = 0;
+        vec[fp.per[i]] = 1;
+        fp.e[i] = numberof(vec, V);
+        if (abs(fp.e[i]) > V.n)
+        /* the standard-base must occur in the set of short vectors, since Id
+           is certainly an automorphism */
+        {
+            fprintf(stderr, "Error: standard basis vector nr. %d not found\n",
+                    i);
+            exit(2);
+        }
+    }
+    free(vec);
+    /* if the -D option is given, the scalar product combinations and the
+       corresponding vector sums are computed for the standard-basis */
+    if (flags.DEPTH > 0) {
+        if ((comb = (scpcomb *)malloc(dim * sizeof(scpcomb))) == 0)
+            exit(2);
+        for (i = 0; i < dim; ++i) {
+            /* compute the list of scalar product combinations and the
+               corresponding vector sums */
+            scpvecs(&comb[i].list, &sumveclist, i, fp.e, flags.DEPTH, V, F);
+            /* compute a basis for the lattice that is generated by the vector
+               sums and a transformation matrix that expresses the basis in
+               terms of the vector sums */
+            base(&comb[i], &sumvecbase, sumveclist, F.A[0], dim);
+            if (flags.PRINT == 1)
+            /* if the -P option is given, print the rank of the lattice
+               generated by the vector sums on level i on AUTO.tmp */
+            {
+                outfile = fopen("AUTO.tmp", "a");
+                fprintf(outfile, "comb[%d].rank = %d\n", i, comb[i].rank);
+                fclose(outfile);
+            }
+            /* compute the coefficients of the vector sums in terms of the
+             * basis */
+            coef(&comb[i], sumvecbase, sumveclist, F.A[0], dim);
+            for (j = 0; j <= comb[i].list.n; ++j)
+                free(sumveclist[j]);
+            free(sumveclist);
+            /* compute the scalar products of the base-vectors */
+            scpforms(&comb[i], sumvecbase, F);
+            for (j = 0; j < comb[i].rank; ++j)
+                free(sumvecbase[j]);
+            free(sumvecbase);
+        }
+    }
+    /* the Bacher-polynomials for the first BACHDEP base-vectors are computed,
+       if no scalar product was given as an argument, the scalar product is
+       set
+       to 1/2 the norm of the base-vector (with respect to the first form) */
+    if (flags.BACH[0] == 1) {
+        if ((bach = (bachpol *)malloc(flags.BACHDEP * sizeof(bachpol))) == 0)
+            exit(2);
+        for (i = 0; i < flags.BACHDEP; ++i) {
+            if (flags.BACH[2] == 0)
+                /* no scalar product was given as an option */
+                flags.BACHSCP = V.v[fp.e[i]][dim] / 2;
+            /* compute the Bacher-polynomial */
+            bacher(&bach[i], fp.e[i], flags.BACHSCP, V, F.v[0]);
+            if (flags.PRINT == 1)
+            /* if the -P option is given, print the Bacher-polynomial on
+               AUTO.tmp */
+            {
+                outfile = fopen("AUTO.tmp", "a");
+                fprintf(outfile,
+                        "Bacher-polynomial of base vector fp.e[%d]:\n", i);
+                fputbach(outfile, bach[i]);
+                fclose(outfile);
+            }
+        }
+    }
+    /* set up the group: the generators in G.g[i] are matrices that fix the
+       first i base-vectors but do not fix fp.e[i] */
+    if ((G.g = (int ****)malloc(dim * sizeof(int ***))) == 0)
+        exit(2);
+    /* G.ng is the number of generators in G.g[i] */
+    if ((G.ng = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    /* the first G.nsg[i] generators in G.g[i] are obtained as stabilizer
+       elements and are not necessary to generate the group */
+    if ((G.nsg = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    /* G.ord[i] is the orbit length of fp.e[i] under the generators in
+       G.g[i] ... G.g[dim-1] */
+    if ((G.ord = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    for (i = 0; i < dim; ++i) {
+        if ((G.g[i] = (int ***)malloc(1 * sizeof(int **))) == 0)
+            exit(2);
+        G.ng[i] = 0;
+        G.nsg[i] = 0;
+    }
+    G.dim = dim;
+    if ((G.g[0][0] = (int **)malloc(dim * sizeof(int *))) == 0)
+        exit(2);
+    /* -Id is always an automorphism */
+    for (i = 0; i < dim; ++i) {
+        if ((G.g[0][0][i] = (int *)malloc(dim * sizeof(int))) == 0)
+            exit(2);
+        for (j = 0; j < dim; ++j)
+            G.g[0][0][i][j] = 0;
+        G.g[0][0][i][i] = -1;
+        G.ng[0] = 1;
+    }
+    /* fill in the generators which were given as input */
+    for (i = 0; i < nH; ++i) {
+        for (j = 0; j < dim && operate(fp.e[j], H[i], V) == fp.e[j]; ++j)
+            ;
+        if (j < dim)
+        /* the generator is not Id and fixes fp.e[0],...,fp.e[j-1] but not
+           fp.e[j] */
+        {
+            ++G.ng[j];
+            if ((G.g[j] =
+                     (int ***)realloc(G.g[j], G.ng[j] * sizeof(int **))) == 0)
+                exit(2);
+            if ((G.g[j][G.ng[j] - 1] = (int **)malloc(dim * sizeof(int *))) ==
+                0)
+                exit(2);
+            for (k = 0; k < dim; ++k) {
+                if ((G.g[j][G.ng[j] - 1][k] =
+                         (int *)malloc(dim * sizeof(int))) == 0)
+                    exit(2);
+                for (l = 0; l < dim; ++l)
+                    G.g[j][G.ng[j] - 1][k][l] = H[i][k][l];
+            }
+        }
+        for (k = 0; k < dim; ++k)
+            free(H[i][k]);
+        free(H[i]);
+    }
+    if (nH > 0)
+        free(H);
+    nH = 0;
+    for (i = 0; i < dim; ++i)
+        nH += G.ng[i];
+    if ((H = (int ***)malloc(nH * sizeof(int **))) == 0)
+        exit(2);
+    /* calculate the orbit lengths under the automorphisms known so far */
+    for (i = 0; i < dim; ++i) {
+        if (G.ng[i] > 0) {
+            nH = 0;
+            for (j = i; j < dim; ++j) {
+                for (k = 0; k < G.ng[j]; ++k) {
+                    H[nH] = G.g[j][k];
+                    ++nH;
+                }
+            }
+            G.ord[i] = orbitlen(fp.e[i], fp.diag[i], H, nH, V);
+        }
+        else
+            G.ord[i] = 1;
+    }
+    free(H);
+    /* compute the full automorphism group */
+    autom(&G, V, F, fp, comb, bach, flags);
+    /* print the generators of the group, which are necessary for generating
+     */
+    B = putgens(G, flags);
+    n = 0;
+    for (i = flags.STAB; i < dim; ++i) {
+        if (G.ord[i] > 1)
+            ++n;
+    }
+    /* print a base to AUTO.tmp if the print-flag is set */
+    if (flags.PRINT == 1) {
+        outfile = fopen("AUTO.tmp", "a");
+        fprintf(outfile, "%dx%d\n", n, dim);
+        for (i = flags.STAB; i < dim; ++i) {
+            if (G.ord[i] > 1) {
+                for (j = 0; j < dim; ++j)
+                    fprintf(outfile, " %d", V.v[fp.e[i]][j]);
+                fprintf(outfile, "\n");
+            }
+        }
+        fclose(outfile);
+    }
+    /* print the order of the group */
+    putord(G, flags, B);
+
+
+    if (flags.BACH[0] == 1) {
+        for (i = 0; i < flags.BACHDEP; ++i)
+            free(bach[i].coef);
+        free(bach);
+    }
+    if (flags.DEPTH > 0) {
+        for (i = 0; i < dim; i++) {
+            for (j = 0; j <= comb[i].list.n; j++)
+                free(comb[i].coef[j]);
+            free(comb[i].coef);
+            for (j = 0; j <= comb[i].list.n; j++)
+                free(comb[i].list.v[j]);
+            free(comb[i].list.v);
+            for (j = 0; j < comb[i].rank; j++)
+                free(comb[i].trans[j]);
+            free(comb[i].trans);
+            for (j = 0; j < F.n; j++) {
+                for (k = 0; k < comb[i].rank; k++)
+                    free(comb[i].F[j][k]);
+                free(comb[i].F[j]);
+            }
+            free(comb[i].F);
+        }
+        free(comb);
+    }
+    for (i = 0; i < F.n; i++) {
+        for (j = 1; j <= V.n; j++)
+            free(F.v[i][j]);
+        free(F.v[i]);
+        for (j = 0; j < dim; j++)
+            free(F.A[i][j]);
+        free(F.A[i]);
+    }
+    free(F.A);
+    free(F.v);
+    for (i = 0; i <= V.n; i++)
+        free(V.v[i]);
+    free(V.v);
+    free(fp.diag);
+    free(fp.per);
+    free(fp.e);
+    for (i = 0; i < dim; i++) {
+        for (j = 0; j < G.ng[i]; j++) {
+            for (k = 0; k < dim; k++)
+                free(G.g[i][j][k]);
+            free(G.g[i][j]);
+        }
+        free(G.g[i]);
+    }
+    free(G.g);
+    free(G.ord);
+    free(G.ng);
+    free(G.nsg);
+
+    return (B);
 }
 
 
@@ -581,7 +572,7 @@ autgrp (matrix_TYP **Fo, int Foanz, matrix_TYP *SV, matrix_TYP **Erz, int Erzanz
 @ Pbase:    a set of matrices
 @ Pdim:     the number of matrices given in 'Pbase'.
 @
-@ This function is designed to calculate the stabilizer of a perfect 
+@ This function is designed to calculate the stabilizer of a perfect
 @ form 'Fo' in the normalizer of the group generated by the matrices
 @ given in 'Erz'.
 @ Then 'P' is the set of matrices given by the Voronoi-directions of 'Fo'
@@ -592,493 +583,490 @@ autgrp (matrix_TYP **Fo, int Foanz, matrix_TYP *SV, matrix_TYP **Erz, int Erzanz
 \**************************************************************************/
 
 
-bravais_TYP *
-perfect_normal_autgrp (matrix_TYP *Fo, matrix_TYP *SV, matrix_TYP **Erz, int Erzanz, int *options, matrix_TYP **P, int Panz, matrix_TYP **Pbase, int Pdim)
+bravais_TYP * perfect_normal_autgrp(matrix_TYP *  Fo,
+                                    matrix_TYP *  SV,
+                                    matrix_TYP ** Erz,
+                                    int           Erzanz,
+                                    int *         options,
+                                    matrix_TYP ** P,
+                                    int           Panz,
+                                    matrix_TYP ** Pbase,
+                                    int           Pdim)
 {
-	FILE		*outfile;
-	bachpol		*bach = 0;
-	flagstruct	flags;
-	scpcomb		*comb = 0;
-	group		G;
-	invar		F;
-	veclist		V, norm;
-	fpstruct	fp;
-	int		dim, max, fail, *vec;
-	int		***H = 0, nH = 0, ngen, **sumveclist, **sumvecbase;
-	int		i, j, k, l, n, *Vvi, *Vvj, **Fvi, *Fvij, **FAi;
-        bravais_TYP *B;
+    FILE *        outfile;
+    bachpol *     bach = 0;
+    flagstruct    flags;
+    scpcomb *     comb = 0;
+    group         G;
+    invar         F;
+    veclist       V, norm;
+    fpstruct      fp;
+    int           dim, max, fail, *vec;
+    int ***       H = 0, nH = 0, ngen, **sumveclist, **sumvecbase;
+    int           i, j, k, l, n, *Vvi, *Vvj, **Fvi, *Fvij, **FAi;
+    bravais_TYP * B;
 
-        normal_option = TRUE;
-        perp_no = Panz;
-        perpdim = Pdim;
-/* get the flags from the command line */
-	getflags(&flags, options);
-   if(Erzanz > 0)
-     flags.GEN = 1;
-   else
-     flags.GEN = 0;
-/* F.n is the number of invariant forms */
-	F.n = 1;
-	if ((F.A = (int***)malloc(1 *sizeof(int**))) == 0)
-		exit (2);
-/* read the invariant forms */
-        F.dim = Fo->cols;
-	dim = F.dim;
-         if(Fo->cols != F.dim || Fo->rows != F.dim)
-         {
-            printf("error form 'Fo' in autgrp must be a square matrix\n");
-            exit(3);
-         }
-	  if ((F.A[0] = (int**)malloc(dim * sizeof(int*))) == 0)
-		exit (2);
-          for(j=0;j<F.dim;j++)
-          {
-	    if ((F.A[0][j] = (int*)malloc(dim * sizeof(int))) == 0)
-		  exit (2);
-            for(k=0;k<F.dim;k++)
-              F.A[0][j][k] = Fo->array.SZ[j][k];
-          }
-	if (flags.GEN == 1)
-/* some automorphisms are already known */
-	{
-		ngen = Erzanz;
-		if ((H = (int***)malloc(ngen * sizeof(int**))) == 0)
-			exit (2);
-		nH = 0;
-		fail = 0;
-                for(i=0;i<ngen;i++)
-                {
-                  if(Erz[i]->cols != dim || Erz[i]->rows != dim)
-                  {
-                    printf("Elements 'Erz' have wrong dimension\n");
-                    exit(2);
-                  }
-                }
-                i = 0;
-		while (nH+fail < ngen)
-		{
-		    if ((H[nH] = (int**)malloc(dim * sizeof(int*))) == 0)
-			exit (2);
-                    for(j=0;j<dim;j++)
-                    {
-		      if ((H[nH][j] = (int*)malloc(dim * sizeof(int))) == 0)
-		  	exit (2);
-                      for(k=0;k<dim;k++)
-                        H[nH][j][k] = Erz[i]->array.SZ[k][j];
-                    }
-/* check whether the matrix is really an automorphism, i.e. fixes the forms */
-			if (checkgen(H[nH], F) == 0)
-/* the matrix is not an automorphism */
-			{
-				++fail;
-				for (j = 0; j < dim; ++j)
-					free(H[nH][j]);
-                                free(H[nH]);
-			}
-			else
-/* the matrix fixes all forms in F */
-				++nH;
-                    i++;
-		}
-	}
-	else
-		nH = 0;
-
-
-
-	V.dim = dim;
-	V.len = dim + F.n;
-/* get the short vectors */
-        V.n = SV->rows;
-        if ((V.v = (int**)malloc((V.n+1) * sizeof(int*))) == 0)
-			exit (2);
-        if ((V.v[0] = (int*)malloc(V.len * sizeof(int))) == 0)
-			exit (2);
-        /* tilman 9/1/97 changed these lines 
-        for(i=1;i<= V.n;i++)
-        {
-               V.v[i] = SV->array.SZ[i-1];
-        } to (next 5 lines): */
-        for(i=1;i<= V.n;i++)
-        {
-           V.v[i] = (int *) malloc((SV->rows+1) * sizeof(int));
-           for (j=0;j<SV->cols;j++){
-              V.v[i][j] = SV->array.SZ[i-1][j];
-           }
-        }
-
-/* the first nonzero entry of each vector is made positive and the maximal
-   entry of the vectors is determined */
-	max = 1;
-	for (i = 1; i <= V.n; ++i)
-	{
-		Vvi = V.v[i];
-		for (j = 0; j < dim  &&  Vvi[j] == 0; ++j);
-		if (j < dim  &&  Vvi[j] < 0)
-		{
-			for (k = j; k < dim; ++k)
-				Vvi[k] *= -1;
-		}
-		for (k = j; k < dim; ++k)
-		{
-			if (abs(Vvi[k]) > max)
-				max = abs(Vvi[k]);
-		}
-	}
-	if (max > MAXENTRY)
-/* there is an entry, which is bigger than MAXENTRY, which might cause overflow,
-   since the program doesn't use long integer arithmetic */
-	{
-		fprintf(stderr, "Error: Found entry %d in short vectors.\nTo avoid overflow, the entries should not exceed %d.\n", max, MAXENTRY);
-		exit (3);
-	}
-/* V.prime is a prime p, such that every entry x in the short vectors remains
-   unchanged under reduction mod p in symmetric form, i.e. -p/2 < x <= p/2 */
-	for (V.prime = 2*max + 1; isprime(V.prime) == 0; ++V.prime);
-/* sort the vectors and delete doublets */
-	sortvecs(&V);
-/* the norm-vector (i.e. the vector of the norms with respect to the different
-   invariant forms) of each vector must be equal to the norm-vector of one
-   of the vectors from the standard-base */
-	if ((norm.v = (int**)malloc((dim+1) * sizeof(int*))) == 0)
-		exit (2);
-	norm.n = dim;
-	norm.dim = F.n;
-	norm.len = F.n;
-	for (i = 1; i <= norm.n; ++i)
-	{
-/* norm.v[i] is the norm combination of the (i-1)-th base-vector */
-		if ((norm.v[i] = (int*)malloc(norm.dim * sizeof(int))) == 0)
-			exit (2);
-		for (k = 0; k < norm.dim; ++k)
-			norm.v[i][k] = F.A[k][i-1][i-1];
-	}
-	sortvecs(&norm);
-/* delete those vectors, which can not be the image of any of the standard-base
-   vectors */
-	checkvecs(&V, F, norm);
-	for (i = 1; i <= norm.n; ++i)
-		free(norm.v[i]);
-	free(norm.v);
-/* print the invariant forms, if output is in ASCII-format */
-/*********************************************
-		printf("#%d\n", F.n);
-		for (i = 0; i < F.n; ++i)
-			putform(F.A[i], dim);
-**********************************************/
-/* F.v[i][j] is the transposed of the product of the Gram-matrix F.A[i] with the
-   transposed of the vector v[j], hence the scalar product of v[j] and v[k] with
-   respect to the Gram-matrix F.A[i] can be computed as standard scalar product
-   of v[j] and F.v[i][k] */
-	if ((F.v = (int***)malloc(F.n * sizeof(int**))) == 0)
-		exit (2);
-/* the product of the maximal entry in the short vectors with the maximal entry
-   in F.v[i] should not exceed MAXNORM to avoid overflow */
-	max = MAXNORM / max;
-	for (i = 0; i < F.n; ++i)
-	{
-		FAi = F.A[i];
-		if ((F.v[i] = (int**)malloc((V.n+1) * sizeof(int*))) == 0)
-			exit (2);
-		Fvi = F.v[i];
-		for (j = 1; j <= V.n; ++j)
-		{
-			Vvj = V.v[j];
-			if ((Fvi[j] = (int*)malloc(dim * sizeof(int))) == 0)
-				exit (2);
-			Fvij = Fvi[j];
-			for (k = 0; k < dim; ++k)
-			{
-				Fvij[k] = sscp(FAi[k], Vvj, dim);
-				if (abs(Fvij[k]) > max)
-/* some entry in F.v[i] is too large */
-				{
-					fprintf(stderr, "Error: Found entry %d in F.v.\nTo avoid overflow, the entries should not exceed %d.\n", Fvij[k], max);
-					exit (3);
-				}
-			}
-		}
-	}
-/* fp.per is the order in which the images of the base-vectors are set */
-	if ((fp.per = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-/* fp.e[i] is the index in V.v of the i-th vector of the standard-base in the 
-   new order */
-	if ((fp.e = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-/* fp.diag is the diagonal of the fingerprint in the new order, fp.diag[i] is
-   an upper bound for the length of the orbit of the i-th base-vector under
-   the stabilizer of the preceding ones */
-	if ((fp.diag = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-/* compute the fingerprint */
-	fingerprint(&fp, F, V);
-        mach_perp_matrices(fp, P, Pbase, dim);
-        pointer_mat_quicksort(perp, 0, perp_no-1, dim, dim, pointer_lower_triangular_mat_comp);
-	if (flags.PRINT == 1)
-/* if the -P option is given, print the diagonal fp.diag and the number of short
-   vectors on AUTO.tmp */
-	{
-		outfile = fopen("AUTO.tmp", "a");
-		fprintf(outfile, "%d short vectors\n", 2*V.n);
-		fprintf(outfile, "fingerprint diagonal:\n");
-		for (i = 0; i < dim; ++i)
-			fprintf(outfile, " %2d", fp.diag[i]);
-		fprintf(outfile, "\n");
-		fclose(outfile);
-	}
-/* get the standard basis in the new order */
-	if ((vec = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-	for (i = 0; i < dim; ++i)
-	{
-		for (j = 0; j < dim; ++j)
-			vec[j] = 0;
-		vec[fp.per[i]] = 1;
-		fp.e[i] = numberof(vec, V);
-		if (abs(fp.e[i]) > V.n)
-/* the standard-base must occur in the set of short vectors, since Id is
-   certainly an automorphism */
-		{
-			fprintf(stderr, "Error: standard basis vector nr. %d not found\n", i);
-			exit (3);
-		}
-	}
-	free(vec);
-/* if the -D option is given, the scalar product combinations and the 
-   corresponding vector sums are computed for the standard-basis */
-	if (flags.DEPTH > 0)
-	{
-		if ((comb = (scpcomb*)malloc(dim * sizeof(scpcomb))) == 0)
-			exit (3);
-		for (i = 0; i < dim; ++i)
-		{
-/* compute the list of scalar product combinations and the corresponding
-   vector sums */
-			scpvecs(&comb[i].list, &sumveclist, i, fp.e, flags.DEPTH, V, F);
-/* compute a basis for the lattice that is generated by the vector sums and
-   a transformation matrix that expresses the basis in terms of the 
-   vector sums */
-			base(&comb[i], &sumvecbase, sumveclist, F.A[0], dim);
-			if (flags.PRINT == 1)
-/* if the -P option is given, print the rank of the lattice generated by the
-   vector sums on level i on AUTO.tmp */
-			{
-				outfile = fopen("AUTO.tmp", "a");
-				fprintf(outfile, "comb[%d].rank = %d\n", i, comb[i].rank);
-				fclose(outfile);
-			}
-/* compute the coefficients of the vector sums in terms of the basis */
-			coef(&comb[i], sumvecbase, sumveclist, F.A[0], dim);
-			for (j = 0; j <= comb[i].list.n; ++j)
-				free(sumveclist[j]);
-			free(sumveclist);
-/* compute the scalar products of the base-vectors */
-			scpforms(&comb[i], sumvecbase, F);
-			for (j = 0; j < comb[i].rank; ++j)
-				free(sumvecbase[j]);
-			free(sumvecbase);
-		}
-	}
-/* the Bacher-polynomials for the first BACHDEP base-vectors are computed,
-   if no scalar product was given as an argument, the scalar product is set
-   to 1/2 the norm of the base-vector (with respect to the first form) */
-	if (flags.BACH[0] == 1)
-	{
-		if ((bach = (bachpol*)malloc(flags.BACHDEP * sizeof(bachpol))) == 0)
-			exit (2);
-		for (i = 0; i < flags.BACHDEP; ++i)
-		{
-			if (flags.BACH[2] == 0)
-/* no scalar product was given as an option */
-				flags.BACHSCP = V.v[fp.e[i]][dim] / 2;
-/* compute the Bacher-polynomial */
-			bacher(&bach[i], fp.e[i], flags.BACHSCP, V, F.v[0]);
-			if (flags.PRINT == 1)
-/* if the -P option is given, print the Bacher-polynomial on AUTO.tmp */
-			{
-				outfile = fopen("AUTO.tmp", "a");
-				fprintf(outfile, "Bacher-polynomial of base vector fp.e[%d]:\n", i);
-				fputbach(outfile, bach[i]);
-				fclose(outfile);
-			}
-		}
-	}
-/* set up the group: the generators in G.g[i] are matrices that fix the
-   first i base-vectors but do not fix fp.e[i] */
-	if ((G.g = (int****)malloc(dim * sizeof(int***))) == 0)
-		exit (2);
-/* G.ng is the number of generators in G.g[i] */
-	if ((G.ng = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-/* the first G.nsg[i] generators in G.g[i] are obtained as stabilizer elements
-   and are not necessary to generate the group */
-	if ((G.nsg = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-/* G.ord[i] is the orbit length of fp.e[i] under the generators in 
-   G.g[i] ... G.g[dim-1] */
-	if ((G.ord = (int*)malloc(dim * sizeof(int))) == 0)
-		exit (2);
-	for (i = 0; i < dim; ++i)
-	{
-		if ((G.g[i] = (int***)malloc(1 * sizeof(int**))) == 0)
-			exit (2);
-		G.ng[i] = 0;
-		G.nsg[i] = 0;
-	}
-	G.dim = dim;
-	if ((G.g[0][0] = (int**)malloc(dim * sizeof(int*))) == 0)
-		exit (2);
-/* -Id is always an automorphism */
-	for (i = 0; i < dim; ++i)
-	{
-		if ((G.g[0][0][i] = (int*)malloc(dim * sizeof(int))) == 0)
-			exit (2);
-		for (j = 0; j < dim; ++j)
-			G.g[0][0][i][j] = 0;
-		G.g[0][0][i][i] = -1;
-		G.ng[0] = 1;
-	}
-/* fill in the generators which were given as input */
-	for (i = 0; i < nH; ++i)
-	{
-		for (j = 0; j < dim  &&  operate(fp.e[j], H[i], V) == fp.e[j]; ++j);
-		if (j < dim)
-/* the generator is not Id and fixes fp.e[0],...,fp.e[j-1] but not fp.e[j] */
-		{
-			++G.ng[j];
-			if ((G.g[j] = (int***)realloc(G.g[j], G.ng[j] * sizeof(int**))) == 0)
-				exit (2);
-			if ((G.g[j][G.ng[j]-1] = (int**)malloc(dim * sizeof(int*))) == 0)
-				exit (2);
-			for (k = 0; k < dim; ++k)
-			{
-				if ((G.g[j][G.ng[j]-1][k] = (int*)malloc(dim * sizeof(int))) == 0)
-					exit (2);
-				for (l = 0; l < dim; ++l)
-					G.g[j][G.ng[j]-1][k][l] = H[i][k][l];
-			}
-		}
-		for (k = 0; k < dim; ++k)
-			free(H[i][k]);
-		free(H[i]);
-	}
-	if (nH > 0)
-		free(H);
-	nH = 0;
-	for (i = 0; i < dim; ++i)
-		nH += G.ng[i];
-	if ((H = (int***)malloc(nH * sizeof(int**))) == 0)
-		exit (2);
-/* calculate the orbit lengths under the automorphisms known so far */
-	for (i = 0; i < dim; ++i)
-	{
-		if (G.ng[i] > 0)
-		{
-			nH = 0;
-			for (j = i; j < dim; ++j)
-			{
-				for (k = 0; k < G.ng[j]; ++k)
-				{
-					H[nH] = G.g[j][k];
-					++nH;
-				}
-			}
-			G.ord[i] = orbitlen(fp.e[i], fp.diag[i], H, nH, V);
-		}
-		else
-			G.ord[i] = 1;
-	}
-	free(H);
-/* compute the full automorphism group */
-	autom(&G, V, F, fp, comb, bach, flags);
-/* print the generators of the group, which are necessary for generating */
-	B = putgens(G, flags);
-	n = 0;
-	for (i = flags.STAB; i < dim; ++i)
-	{
-		if (G.ord[i] > 1)
-			++n;
-	}
-/* print a base to AUTO.tmp if the print-flag is set */
-	if (flags.PRINT == 1)
-	{
-		outfile = fopen("AUTO.tmp", "a");
-		fprintf(outfile, "%dx%d\n", n, dim);
-		for (i = flags.STAB; i < dim; ++i)
-		{
-			if (G.ord[i] > 1)
-			{
-				for (j = 0; j < dim; ++j)
-					fprintf(outfile, " %d", V.v[fp.e[i]][j]);
-				fprintf(outfile, "\n");
-			}
-		}
-		fclose(outfile);
-	}
-/* print the order of the group */
-	putord(G, flags, B);
-
-
-	if (flags.BACH[0] == 1)
-	{
-		for (i = 0; i < flags.BACHDEP; ++i)
-                   free(bach[i].coef);
-                free(bach);
-        }
-	if (flags.DEPTH > 0)
-	{
-            for(i=0;i<dim;i++)
-            {
-              for(j=0;j<=comb[i].list.n;j++)
-                free(comb[i].coef[j]);
-              free(comb[i].coef);
-              for(j=0;j<=comb[i].list.n;j++)
-                free(comb[i].list.v[j]);
-              free(comb[i].list.v);
-              for(j=0;j<comb[i].rank;j++)
-                free(comb[i].trans[j]);
-              free(comb[i].trans);
-              for(j=0;j<F.n;j++)
-              {
-                 for(k=0;k<comb[i].rank;k++)
-                    free(comb[i].F[j][k]);
-                 free(comb[i].F[j]);
-              }
-              free(comb[i].F);
+    normal_option = TRUE;
+    perp_no = Panz;
+    perpdim = Pdim;
+    /* get the flags from the command line */
+    getflags(&flags, options);
+    if (Erzanz > 0)
+        flags.GEN = 1;
+    else
+        flags.GEN = 0;
+    /* F.n is the number of invariant forms */
+    F.n = 1;
+    if ((F.A = (int ***)malloc(1 * sizeof(int **))) == 0)
+        exit(2);
+    /* read the invariant forms */
+    F.dim = Fo->cols;
+    dim = F.dim;
+    if (Fo->cols != F.dim || Fo->rows != F.dim) {
+        printf("error form 'Fo' in autgrp must be a square matrix\n");
+        exit(3);
+    }
+    if ((F.A[0] = (int **)malloc(dim * sizeof(int *))) == 0)
+        exit(2);
+    for (j = 0; j < F.dim; j++) {
+        if ((F.A[0][j] = (int *)malloc(dim * sizeof(int))) == 0)
+            exit(2);
+        for (k = 0; k < F.dim; k++)
+            F.A[0][j][k] = Fo->array.SZ[j][k];
+    }
+    if (flags.GEN == 1)
+    /* some automorphisms are already known */
+    {
+        ngen = Erzanz;
+        if ((H = (int ***)malloc(ngen * sizeof(int **))) == 0)
+            exit(2);
+        nH = 0;
+        fail = 0;
+        for (i = 0; i < ngen; i++) {
+            if (Erz[i]->cols != dim || Erz[i]->rows != dim) {
+                printf("Elements 'Erz' have wrong dimension\n");
+                exit(2);
             }
-            free(comb);
         }
-        for(i=0;i<F.n;i++)
+        i = 0;
+        while (nH + fail < ngen) {
+            if ((H[nH] = (int **)malloc(dim * sizeof(int *))) == 0)
+                exit(2);
+            for (j = 0; j < dim; j++) {
+                if ((H[nH][j] = (int *)malloc(dim * sizeof(int))) == 0)
+                    exit(2);
+                for (k = 0; k < dim; k++)
+                    H[nH][j][k] = Erz[i]->array.SZ[k][j];
+            }
+            /* check whether the matrix is really an automorphism, i.e. fixes
+             * the forms */
+            if (checkgen(H[nH], F) == 0)
+            /* the matrix is not an automorphism */
+            {
+                ++fail;
+                for (j = 0; j < dim; ++j)
+                    free(H[nH][j]);
+                free(H[nH]);
+            }
+            else
+                /* the matrix fixes all forms in F */
+                ++nH;
+            i++;
+        }
+    }
+    else
+        nH = 0;
+
+
+    V.dim = dim;
+    V.len = dim + F.n;
+    /* get the short vectors */
+    V.n = SV->rows;
+    if ((V.v = (int **)malloc((V.n + 1) * sizeof(int *))) == 0)
+        exit(2);
+    if ((V.v[0] = (int *)malloc(V.len * sizeof(int))) == 0)
+        exit(2);
+    /* tilman 9/1/97 changed these lines
+    for(i=1;i<= V.n;i++)
+    {
+           V.v[i] = SV->array.SZ[i-1];
+    } to (next 5 lines): */
+    for (i = 1; i <= V.n; i++) {
+        V.v[i] = (int *)malloc((SV->rows + 1) * sizeof(int));
+        for (j = 0; j < SV->cols; j++) {
+            V.v[i][j] = SV->array.SZ[i - 1][j];
+        }
+    }
+
+    /* the first nonzero entry of each vector is made positive and the maximal
+       entry of the vectors is determined */
+    max = 1;
+    for (i = 1; i <= V.n; ++i) {
+        Vvi = V.v[i];
+        for (j = 0; j < dim && Vvi[j] == 0; ++j)
+            ;
+        if (j < dim && Vvi[j] < 0) {
+            for (k = j; k < dim; ++k)
+                Vvi[k] *= -1;
+        }
+        for (k = j; k < dim; ++k) {
+            if (abs(Vvi[k]) > max)
+                max = abs(Vvi[k]);
+        }
+    }
+    if (max > MAXENTRY)
+    /* there is an entry, which is bigger than MAXENTRY, which might cause
+       overflow, since the program doesn't use long integer arithmetic */
+    {
+        fprintf(stderr,
+                "Error: Found entry %d in short vectors.\nTo avoid overflow, "
+                "the entries should not exceed %d.\n",
+                max, MAXENTRY);
+        exit(3);
+    }
+    /* V.prime is a prime p, such that every entry x in the short vectors
+       remains
+       unchanged under reduction mod p in symmetric form, i.e. -p/2 < x <= p/2
+     */
+    for (V.prime = 2 * max + 1; isprime(V.prime) == 0; ++V.prime)
+        ;
+    /* sort the vectors and delete doublets */
+    sortvecs(&V);
+    /* the norm-vector (i.e. the vector of the norms with respect to the
+       different invariant forms) of each vector must be equal to the
+       norm-vector of one of the vectors from the standard-base */
+    if ((norm.v = (int **)malloc((dim + 1) * sizeof(int *))) == 0)
+        exit(2);
+    norm.n = dim;
+    norm.dim = F.n;
+    norm.len = F.n;
+    for (i = 1; i <= norm.n; ++i) {
+        /* norm.v[i] is the norm combination of the (i-1)-th base-vector */
+        if ((norm.v[i] = (int *)malloc(norm.dim * sizeof(int))) == 0)
+            exit(2);
+        for (k = 0; k < norm.dim; ++k)
+            norm.v[i][k] = F.A[k][i - 1][i - 1];
+    }
+    sortvecs(&norm);
+    /* delete those vectors, which can not be the image of any of the
+       standard-base vectors */
+    checkvecs(&V, F, norm);
+    for (i = 1; i <= norm.n; ++i)
+        free(norm.v[i]);
+    free(norm.v);
+    /* print the invariant forms, if output is in ASCII-format */
+    /*********************************************
+                    printf("#%d\n", F.n);
+                    for (i = 0; i < F.n; ++i)
+                            putform(F.A[i], dim);
+    **********************************************/
+    /* F.v[i][j] is the transposed of the product of the Gram-matrix F.A[i]
+       with the transposed of the vector v[j], hence the scalar product of
+       v[j] and v[k] with respect to the Gram-matrix F.A[i] can be computed as
+       standard scalar product of v[j] and F.v[i][k] */
+    if ((F.v = (int ***)malloc(F.n * sizeof(int **))) == 0)
+        exit(2);
+    /* the product of the maximal entry in the short vectors with the maximal
+       entry in F.v[i] should not exceed MAXNORM to avoid overflow */
+    max = MAXNORM / max;
+    for (i = 0; i < F.n; ++i) {
+        FAi = F.A[i];
+        if ((F.v[i] = (int **)malloc((V.n + 1) * sizeof(int *))) == 0)
+            exit(2);
+        Fvi = F.v[i];
+        for (j = 1; j <= V.n; ++j) {
+            Vvj = V.v[j];
+            if ((Fvi[j] = (int *)malloc(dim * sizeof(int))) == 0)
+                exit(2);
+            Fvij = Fvi[j];
+            for (k = 0; k < dim; ++k) {
+                Fvij[k] = sscp(FAi[k], Vvj, dim);
+                if (abs(Fvij[k]) > max)
+                /* some entry in F.v[i] is too large */
+                {
+                    fprintf(stderr,
+                            "Error: Found entry %d in F.v.\nTo avoid "
+                            "overflow, the entries should not exceed %d.\n",
+                            Fvij[k], max);
+                    exit(3);
+                }
+            }
+        }
+    }
+    /* fp.per is the order in which the images of the base-vectors are set */
+    if ((fp.per = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    /* fp.e[i] is the index in V.v of the i-th vector of the standard-base in
+       the new order */
+    if ((fp.e = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    /* fp.diag is the diagonal of the fingerprint in the new order, fp.diag[i]
+       is an upper bound for the length of the orbit of the i-th base-vector
+       under the stabilizer of the preceding ones */
+    if ((fp.diag = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    /* compute the fingerprint */
+    fingerprint(&fp, F, V);
+    mach_perp_matrices(fp, P, Pbase, dim);
+    pointer_mat_quicksort(perp, 0, perp_no - 1, dim, dim,
+                          pointer_lower_triangular_mat_comp);
+    if (flags.PRINT == 1)
+    /* if the -P option is given, print the diagonal fp.diag and the number of
+       short vectors on AUTO.tmp */
+    {
+        outfile = fopen("AUTO.tmp", "a");
+        fprintf(outfile, "%d short vectors\n", 2 * V.n);
+        fprintf(outfile, "fingerprint diagonal:\n");
+        for (i = 0; i < dim; ++i)
+            fprintf(outfile, " %2d", fp.diag[i]);
+        fprintf(outfile, "\n");
+        fclose(outfile);
+    }
+    /* get the standard basis in the new order */
+    if ((vec = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    for (i = 0; i < dim; ++i) {
+        for (j = 0; j < dim; ++j)
+            vec[j] = 0;
+        vec[fp.per[i]] = 1;
+        fp.e[i] = numberof(vec, V);
+        if (abs(fp.e[i]) > V.n)
+        /* the standard-base must occur in the set of short vectors, since Id
+           is certainly an automorphism */
         {
-          for(j=1;j<=V.n;j++)
+            fprintf(stderr, "Error: standard basis vector nr. %d not found\n",
+                    i);
+            exit(3);
+        }
+    }
+    free(vec);
+    /* if the -D option is given, the scalar product combinations and the
+       corresponding vector sums are computed for the standard-basis */
+    if (flags.DEPTH > 0) {
+        if ((comb = (scpcomb *)malloc(dim * sizeof(scpcomb))) == 0)
+            exit(3);
+        for (i = 0; i < dim; ++i) {
+            /* compute the list of scalar product combinations and the
+               corresponding vector sums */
+            scpvecs(&comb[i].list, &sumveclist, i, fp.e, flags.DEPTH, V, F);
+            /* compute a basis for the lattice that is generated by the vector
+               sums and a transformation matrix that expresses the basis in
+               terms of the vector sums */
+            base(&comb[i], &sumvecbase, sumveclist, F.A[0], dim);
+            if (flags.PRINT == 1)
+            /* if the -P option is given, print the rank of the lattice
+               generated by the vector sums on level i on AUTO.tmp */
+            {
+                outfile = fopen("AUTO.tmp", "a");
+                fprintf(outfile, "comb[%d].rank = %d\n", i, comb[i].rank);
+                fclose(outfile);
+            }
+            /* compute the coefficients of the vector sums in terms of the
+             * basis */
+            coef(&comb[i], sumvecbase, sumveclist, F.A[0], dim);
+            for (j = 0; j <= comb[i].list.n; ++j)
+                free(sumveclist[j]);
+            free(sumveclist);
+            /* compute the scalar products of the base-vectors */
+            scpforms(&comb[i], sumvecbase, F);
+            for (j = 0; j < comb[i].rank; ++j)
+                free(sumvecbase[j]);
+            free(sumvecbase);
+        }
+    }
+    /* the Bacher-polynomials for the first BACHDEP base-vectors are computed,
+       if no scalar product was given as an argument, the scalar product is
+       set
+       to 1/2 the norm of the base-vector (with respect to the first form) */
+    if (flags.BACH[0] == 1) {
+        if ((bach = (bachpol *)malloc(flags.BACHDEP * sizeof(bachpol))) == 0)
+            exit(2);
+        for (i = 0; i < flags.BACHDEP; ++i) {
+            if (flags.BACH[2] == 0)
+                /* no scalar product was given as an option */
+                flags.BACHSCP = V.v[fp.e[i]][dim] / 2;
+            /* compute the Bacher-polynomial */
+            bacher(&bach[i], fp.e[i], flags.BACHSCP, V, F.v[0]);
+            if (flags.PRINT == 1)
+            /* if the -P option is given, print the Bacher-polynomial on
+               AUTO.tmp */
+            {
+                outfile = fopen("AUTO.tmp", "a");
+                fprintf(outfile,
+                        "Bacher-polynomial of base vector fp.e[%d]:\n", i);
+                fputbach(outfile, bach[i]);
+                fclose(outfile);
+            }
+        }
+    }
+    /* set up the group: the generators in G.g[i] are matrices that fix the
+       first i base-vectors but do not fix fp.e[i] */
+    if ((G.g = (int ****)malloc(dim * sizeof(int ***))) == 0)
+        exit(2);
+    /* G.ng is the number of generators in G.g[i] */
+    if ((G.ng = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    /* the first G.nsg[i] generators in G.g[i] are obtained as stabilizer
+       elements and are not necessary to generate the group */
+    if ((G.nsg = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    /* G.ord[i] is the orbit length of fp.e[i] under the generators in
+       G.g[i] ... G.g[dim-1] */
+    if ((G.ord = (int *)malloc(dim * sizeof(int))) == 0)
+        exit(2);
+    for (i = 0; i < dim; ++i) {
+        if ((G.g[i] = (int ***)malloc(1 * sizeof(int **))) == 0)
+            exit(2);
+        G.ng[i] = 0;
+        G.nsg[i] = 0;
+    }
+    G.dim = dim;
+    if ((G.g[0][0] = (int **)malloc(dim * sizeof(int *))) == 0)
+        exit(2);
+    /* -Id is always an automorphism */
+    for (i = 0; i < dim; ++i) {
+        if ((G.g[0][0][i] = (int *)malloc(dim * sizeof(int))) == 0)
+            exit(2);
+        for (j = 0; j < dim; ++j)
+            G.g[0][0][i][j] = 0;
+        G.g[0][0][i][i] = -1;
+        G.ng[0] = 1;
+    }
+    /* fill in the generators which were given as input */
+    for (i = 0; i < nH; ++i) {
+        for (j = 0; j < dim && operate(fp.e[j], H[i], V) == fp.e[j]; ++j)
+            ;
+        if (j < dim)
+        /* the generator is not Id and fixes fp.e[0],...,fp.e[j-1] but not
+           fp.e[j] */
+        {
+            ++G.ng[j];
+            if ((G.g[j] =
+                     (int ***)realloc(G.g[j], G.ng[j] * sizeof(int **))) == 0)
+                exit(2);
+            if ((G.g[j][G.ng[j] - 1] = (int **)malloc(dim * sizeof(int *))) ==
+                0)
+                exit(2);
+            for (k = 0; k < dim; ++k) {
+                if ((G.g[j][G.ng[j] - 1][k] =
+                         (int *)malloc(dim * sizeof(int))) == 0)
+                    exit(2);
+                for (l = 0; l < dim; ++l)
+                    G.g[j][G.ng[j] - 1][k][l] = H[i][k][l];
+            }
+        }
+        for (k = 0; k < dim; ++k)
+            free(H[i][k]);
+        free(H[i]);
+    }
+    if (nH > 0)
+        free(H);
+    nH = 0;
+    for (i = 0; i < dim; ++i)
+        nH += G.ng[i];
+    if ((H = (int ***)malloc(nH * sizeof(int **))) == 0)
+        exit(2);
+    /* calculate the orbit lengths under the automorphisms known so far */
+    for (i = 0; i < dim; ++i) {
+        if (G.ng[i] > 0) {
+            nH = 0;
+            for (j = i; j < dim; ++j) {
+                for (k = 0; k < G.ng[j]; ++k) {
+                    H[nH] = G.g[j][k];
+                    ++nH;
+                }
+            }
+            G.ord[i] = orbitlen(fp.e[i], fp.diag[i], H, nH, V);
+        }
+        else
+            G.ord[i] = 1;
+    }
+    free(H);
+    /* compute the full automorphism group */
+    autom(&G, V, F, fp, comb, bach, flags);
+    /* print the generators of the group, which are necessary for generating
+     */
+    B = putgens(G, flags);
+    n = 0;
+    for (i = flags.STAB; i < dim; ++i) {
+        if (G.ord[i] > 1)
+            ++n;
+    }
+    /* print a base to AUTO.tmp if the print-flag is set */
+    if (flags.PRINT == 1) {
+        outfile = fopen("AUTO.tmp", "a");
+        fprintf(outfile, "%dx%d\n", n, dim);
+        for (i = flags.STAB; i < dim; ++i) {
+            if (G.ord[i] > 1) {
+                for (j = 0; j < dim; ++j)
+                    fprintf(outfile, " %d", V.v[fp.e[i]][j]);
+                fprintf(outfile, "\n");
+            }
+        }
+        fclose(outfile);
+    }
+    /* print the order of the group */
+    putord(G, flags, B);
+
+
+    if (flags.BACH[0] == 1) {
+        for (i = 0; i < flags.BACHDEP; ++i)
+            free(bach[i].coef);
+        free(bach);
+    }
+    if (flags.DEPTH > 0) {
+        for (i = 0; i < dim; i++) {
+            for (j = 0; j <= comb[i].list.n; j++)
+                free(comb[i].coef[j]);
+            free(comb[i].coef);
+            for (j = 0; j <= comb[i].list.n; j++)
+                free(comb[i].list.v[j]);
+            free(comb[i].list.v);
+            for (j = 0; j < comb[i].rank; j++)
+                free(comb[i].trans[j]);
+            free(comb[i].trans);
+            for (j = 0; j < F.n; j++) {
+                for (k = 0; k < comb[i].rank; k++)
+                    free(comb[i].F[j][k]);
+                free(comb[i].F[j]);
+            }
+            free(comb[i].F);
+        }
+        free(comb);
+    }
+    for (i = 0; i < F.n; i++) {
+        for (j = 1; j <= V.n; j++)
             free(F.v[i][j]);
-          free(F.v[i]);
-          for(j=0;j<dim;j++)
+        free(F.v[i]);
+        for (j = 0; j < dim; j++)
             free(F.A[i][j]);
-          free(F.A[i]);
-        }
-        free(F.A); free(F.v);
+        free(F.A[i]);
+    }
+    free(F.A);
+    free(F.v);
 
-        /* inserted the next 3 lines 9/1/97 tilman */
-        for (j=0;j<=V.n;j++){
-           free(V.v[j]);
-        }
+    /* inserted the next 3 lines 9/1/97 tilman */
+    for (j = 0; j <= V.n; j++) {
+        free(V.v[j]);
+    }
 
-        free(V.v);
-        free_perp_matrices(dim);
-        free(fp.diag); free(fp.per); free(fp.e);
-        for(i=0;i<dim;i++)
-        {
-           for(j=0;j<G.ng[i];j++)
-           {
-             for(k=0;k<dim;k++)
-               free(G.g[i][j][k]);
-             free(G.g[i][j]);
-           }
-           free(G.g[i]);
+    free(V.v);
+    free_perp_matrices(dim);
+    free(fp.diag);
+    free(fp.per);
+    free(fp.e);
+    for (i = 0; i < dim; i++) {
+        for (j = 0; j < G.ng[i]; j++) {
+            for (k = 0; k < dim; k++)
+                free(G.g[i][j][k]);
+            free(G.g[i][j]);
         }
-        free(G.g); free(G.ord); free(G.ng); free(G.nsg);
+        free(G.g[i]);
+    }
+    free(G.g);
+    free(G.ord);
+    free(G.ng);
+    free(G.nsg);
 
-        return(B);
+    return (B);
 }

--- a/functions/ZZ/ZZ_P.h
+++ b/functions/ZZ/ZZ_P.h
@@ -1,5 +1,5 @@
-#ifndef _ZZ_P_H
-#define _ZZ_P_H
+#ifndef CARAT_ZZ_P_H
+#define CARAT_ZZ_P_H
 
 #include <stdio.h>
 #include <math.h>
@@ -126,5 +126,5 @@ extern void ZZ_intern(matrix_TYP * Gram,
 				    ZZ_tree_t * tree,
 				    QtoZ_TYP * inzidenz);
 			
-#endif /* _ZZ_P_H */
+#endif /* CARAT_ZZ_P_H */
 

--- a/functions/ZZ/ZZ_cen_fun_P.h
+++ b/functions/ZZ/ZZ_cen_fun_P.h
@@ -1,5 +1,5 @@
-#ifndef _ZZ_CEN_FUN_P_H
-#define _ZZ_CEN_FUN_P_H
+#ifndef CARAT_ZZ_CEN_FUN_P_H
+#define CARAT_ZZ_CEN_FUN_P_H
 
 #include "typedef.h"
 #include "matrix.h"

--- a/functions/ZZ/ZZ_gen_vs_P.h
+++ b/functions/ZZ/ZZ_gen_vs_P.h
@@ -1,5 +1,5 @@
-#ifndef _ZZ_GEN_VS_P_H
-#define _ZZ_GEN_VS_P_H
+#ifndef CARAT_ZZ_GEN_VS_P_H
+#define CARAT_ZZ_GEN_VS_P_H
 
 #include "typedef.h"
 #include "matrix.h"

--- a/functions/ZZ/ZZ_irr_const_P.h
+++ b/functions/ZZ/ZZ_irr_const_P.h
@@ -1,5 +1,5 @@
-#ifndef _ZZ_IRR_CONST_H
-#define _ZZ_IRR_CONST_H
+#ifndef CARAT_ZZ_IRR_CONST_H
+#define CARAT_ZZ_IRR_CONST_H
 
 #include "matrix.h"
 #include "ZZ_P.h"

--- a/functions/ZZ/ZZ_lll_P.h
+++ b/functions/ZZ/ZZ_lll_P.h
@@ -1,5 +1,5 @@
-#ifndef _ZZ_LLL_P_H
-#define _ZZ_LLL_P_H
+#ifndef CARAT_ZZ_LLL_P_H
+#define CARAT_ZZ_LLL_P_H
 
 #include "ZZ_P.h"
 

--- a/include/ZZ.h
+++ b/include/ZZ.h
@@ -1,5 +1,5 @@
-#ifndef _ZZ_H
-#define _ZZ_H
+#ifndef CARAT_ZZ_H
+#define CARAT_ZZ_H
 
 #include <stdlib.h>		/* for atoi */
 #include "typedef.h"
@@ -34,4 +34,4 @@ extern bravais_TYP **get_groups(bravais_TYP **ADGROUPS,
 extern int NUMBER;		/* Abbruch nach NUMBER Zentrierungen */
 extern int LEVEL;		/* Abbruch nach Iterationszahl LEVEL */
 
-#endif /* _ZZ_H */
+#endif /* CARAT_ZZ_H */

--- a/include/autgrp.h
+++ b/include/autgrp.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_AUTGRP_H_
-#define CARAT_AUTGRP_H_
+#ifndef CARAT_AUTGRP_H
+#define CARAT_AUTGRP_H
 
 #include "typedef.h"
 

--- a/include/autgrp.h
+++ b/include/autgrp.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _AUTGRP_H_
-#define _AUTGRP_H_
+#ifndef CARAT_AUTGRP_H_
+#define CARAT_AUTGRP_H_
 
 #include "typedef.h"
 

--- a/include/base.h
+++ b/include/base.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_BASE_H_
-#define CARAT_BASE_H_
+#ifndef CARAT_BASE_H
+#define CARAT_BASE_H
 
 #include "typedef.h"
 

--- a/include/base.h
+++ b/include/base.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _BASE_H_
-#define _BASE_H_
+#ifndef CARAT_BASE_H_
+#define CARAT_BASE_H_
 
 #include "typedef.h"
 

--- a/include/baum.h
+++ b/include/baum.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _BAUM_H
-#define _BAUM_H
+#ifndef CARAT_BAUM_H
+#define CARAT_BAUM_H
 
 #include "list.h"
 

--- a/include/bravais.h
+++ b/include/bravais.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _BRAVAIS_H_
-#define _BRAVAIS_H_
+#ifndef CARAT_BRAVAIS_H_
+#define CARAT_BRAVAIS_H_
 
 #include "typedef.h"
 

--- a/include/bravais.h
+++ b/include/bravais.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_BRAVAIS_H_
-#define CARAT_BRAVAIS_H_
+#ifndef CARAT_BRAVAIS_H
+#define CARAT_BRAVAIS_H
 
 #include "typedef.h"
 

--- a/include/contrib.h
+++ b/include/contrib.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_CONTRIB_H_
-#define CARAT_CONTRIB_H_
+#ifndef CARAT_CONTRIB_H
+#define CARAT_CONTRIB_H
 
 #include "typedef.h"
 

--- a/include/contrib.h
+++ b/include/contrib.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _CONTRIB_H_
-#define _CONTRIB_H_
+#ifndef CARAT_CONTRIB_H_
+#define CARAT_CONTRIB_H_
 
 #include "typedef.h"
 

--- a/include/datei.h
+++ b/include/datei.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_DATEI_H_
-#define CARAT_DATEI_H_
+#ifndef CARAT_DATEI_H
+#define CARAT_DATEI_H
 
 #include "typedef.h"
 

--- a/include/datei.h
+++ b/include/datei.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _DATEI_H_
-#define _DATEI_H_
+#ifndef CARAT_DATEI_H_
+#define CARAT_DATEI_H_
 
 #include "typedef.h"
 

--- a/include/getput.h
+++ b/include/getput.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_GETPUT_H_
-#define CARAT_GETPUT_H_
+#ifndef CARAT_GETPUT_H
+#define CARAT_GETPUT_H
 
 #include "typedef.h"
 

--- a/include/getput.h
+++ b/include/getput.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _GETPUT_H_
-#define _GETPUT_H_
+#ifndef CARAT_GETPUT_H_
+#define CARAT_GETPUT_H_
 
 #include "typedef.h"
 

--- a/include/graph.h
+++ b/include/graph.h
@@ -2,8 +2,8 @@
    extern "C" {
 #endif
 
-#ifndef _CARAT_GRAPH_H_
-#define _CARAT_GRAPH_H_
+#ifndef CARAT_GRAPH_H
+#define CARAT_GRAPH_H
 
 #include "typedef.h"
 
@@ -394,7 +394,7 @@ int obergruppenzahl(matrix_TYP *L,
 		    int Stab_anz,
 		    int *wort);
 
-#endif /* _CARAT_GRAPH_H_ */
+#endif /* CARAT_GRAPH_H */
 
 #ifdef __cplusplus
    }

--- a/include/hyperbolic.h
+++ b/include/hyperbolic.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _HYPERBOLIC_H_
-#define _HYPERBOLIC_H_
+#ifndef CARAT_HYPERBOLIC_H_
+#define CARAT_HYPERBOLIC_H_
 
 #include "typedef.h"
 

--- a/include/hyperbolic.h
+++ b/include/hyperbolic.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_HYPERBOLIC_H_
-#define CARAT_HYPERBOLIC_H_
+#ifndef CARAT_HYPERBOLIC_H
+#define CARAT_HYPERBOLIC_H
 
 #include "typedef.h"
 

--- a/include/idem.h
+++ b/include/idem.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_IDEM_H_
-#define CARAT_IDEM_H_
+#ifndef CARAT_IDEM_H
+#define CARAT_IDEM_H
 
 #include "typedef.h"
 

--- a/include/idem.h
+++ b/include/idem.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _IDEM_H_
-#define _IDEM_H_
+#ifndef CARAT_IDEM_H_
+#define CARAT_IDEM_H_
 
 #include "typedef.h"
 

--- a/include/list.h
+++ b/include/list.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef CARAT_LINUX_LIST_H
-#define CARAT_LINUX_LIST_H
+#ifndef CARAT_LIST_H
+#define CARAT_LIST_H
 
 /*
  * Simple doubly linked list implementation.

--- a/include/list.h
+++ b/include/list.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef _LINUX_LIST_H
-#define _LINUX_LIST_H
+#ifndef CARAT_LINUX_LIST_H
+#define CARAT_LINUX_LIST_H
 
 /*
  * Simple doubly linked list implementation.

--- a/include/longtools.h
+++ b/include/longtools.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_LONGTOOLS_H_
-#define CARAT_LONGTOOLS_H_
+#ifndef CARAT_LONGTOOLS_H
+#define CARAT_LONGTOOLS_H
 
 #include "typedef.h"
 

--- a/include/longtools.h
+++ b/include/longtools.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _LONGTOOLS_H_
-#define _LONGTOOLS_H_
+#ifndef CARAT_LONGTOOLS_H_
+#define CARAT_LONGTOOLS_H_
 
 #include "typedef.h"
 

--- a/include/matrix.h
+++ b/include/matrix.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_MATRIX_H_
-#define CARAT_MATRIX_H_
+#ifndef CARAT_MATRIX_H
+#define CARAT_MATRIX_H
 
 #include "typedef.h"
 

--- a/include/matrix.h
+++ b/include/matrix.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _MATRIX_H_
-#define _MATRIX_H_
+#ifndef CARAT_MATRIX_H_
+#define CARAT_MATRIX_H_
 
 #include "typedef.h"
 

--- a/include/name.h
+++ b/include/name.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_NAME_H_
-#define CARAT_NAME_H_
+#ifndef CARAT_NAME_H
+#define CARAT_NAME_H
 
 #include "typedef.h"
 

--- a/include/name.h
+++ b/include/name.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _NAME_H_
-#define _NAME_H_
+#ifndef CARAT_NAME_H_
+#define CARAT_NAME_H_
 
 #include "typedef.h"
 

--- a/include/orbit.h
+++ b/include/orbit.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_ORBIT_H_
-#define CARAT_ORBIT_H_
+#ifndef CARAT_ORBIT_H
+#define CARAT_ORBIT_H
 
 #include "typedef.h"
 

--- a/include/orbit.h
+++ b/include/orbit.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _ORBIT_H_
-#define _ORBIT_H_
+#ifndef CARAT_ORBIT_H_
+#define CARAT_ORBIT_H_
 
 #include "typedef.h"
 

--- a/include/polyeder.h
+++ b/include/polyeder.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _POLYEDER_H_
-#define _POLYEDER_H_
+#ifndef CARAT_POLYEDER_H_
+#define CARAT_POLYEDER_H_
 
 #include "typedef.h"
 

--- a/include/polyeder.h
+++ b/include/polyeder.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_POLYEDER_H_
-#define CARAT_POLYEDER_H_
+#ifndef CARAT_POLYEDER_H
+#define CARAT_POLYEDER_H
 
 #include "typedef.h"
 

--- a/include/presentation.h
+++ b/include/presentation.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _PRESENTATION_h_ 
-#define _PRESENTATION_h_
+#ifndef CATAT_PRESENTATION_h_ 
+#define CATAT_PRESENTATION_h_
 
 /**********************************************************************
 |  FILE: presentation.c

--- a/include/presentation.h
+++ b/include/presentation.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CATAT_PRESENTATION_h_ 
-#define CATAT_PRESENTATION_h_
+#ifndef CATAT_PRESENTATION_H
+#define CATAT_PRESENTATION_H
 
 /**********************************************************************
 |  FILE: presentation.c

--- a/include/reduction.h
+++ b/include/reduction.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_REDUCTION_H_
-#define CARAT_REDUCTION_H_
+#ifndef CARAT_REDUCTION_H
+#define CARAT_REDUCTION_H
 
 #include "typedef.h"
 

--- a/include/reduction.h
+++ b/include/reduction.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _REDUCTION_H_
-#define _REDUCTION_H_
+#ifndef CARAT_REDUCTION_H_
+#define CARAT_REDUCTION_H_
 
 #include "typedef.h"
 

--- a/include/sort.h
+++ b/include/sort.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef _SORT_H_
-#define _SORT_H_
+#ifndef CARAT_SORT_H_
+#define CARAT_SORT_H_
 
 #include "typedef.h"
 

--- a/include/sort.h
+++ b/include/sort.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef CARAT_SORT_H_
-#define CARAT_SORT_H_
+#ifndef CARAT_SORT_H
+#define CARAT_SORT_H
 
 #include "typedef.h"
 

--- a/include/symm.h
+++ b/include/symm.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef _SYMM_H_
-#define _SYMM_H_
+#ifndef CARAT_SYMM_H_
+#define CARAT_SYMM_H_
 
 #include "typedef.h"
 

--- a/include/symm.h
+++ b/include/symm.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef CARAT_SYMM_H_
-#define CARAT_SYMM_H_
+#ifndef CARAT_SYMM_H
+#define CARAT_SYMM_H
 
 #include "typedef.h"
 

--- a/include/tietzetrans.h
+++ b/include/tietzetrans.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef _TIETZETRANS_H_
-#define _TIETZETRANS_H_
+#ifndef CARAT_TIETZETRANS_H_
+#define CARAT_TIETZETRANS_H_
 
 typedef struct {
         matrix_TYP* element;

--- a/include/tietzetrans.h
+++ b/include/tietzetrans.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef CARAT_TIETZETRANS_H_
-#define CARAT_TIETZETRANS_H_
+#ifndef CARAT_TIETZETRANS_H
+#define CARAT_TIETZETRANS_H
 
 typedef struct {
         matrix_TYP* element;

--- a/include/tools.h
+++ b/include/tools.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef _TOOLS_H_
-#define _TOOLS_H_
+#ifndef CARAT_TOOLS_H_
+#define CARAT_TOOLS_H_
 
 #include "typedef.h"
 

--- a/include/tools.h
+++ b/include/tools.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef CARAT_TOOLS_H_
-#define CARAT_TOOLS_H_
+#ifndef CARAT_TOOLS_H
+#define CARAT_TOOLS_H
 
 #include "typedef.h"
 

--- a/include/tsubgroups.h
+++ b/include/tsubgroups.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef _TSUBGROUPS_H_
-#define _TSUBGROUPS_H_
+#ifndef CARAT__TSUBGROUPS_H_
+#define CARAT__TSUBGROUPS_H_
 
 #include "typedef.h"
 

--- a/include/tsubgroups.h
+++ b/include/tsubgroups.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef CARAT__TSUBGROUPS_H_
-#define CARAT__TSUBGROUPS_H_
+#ifndef CARAT_TSUBGROUPS_H
+#define CARAT_TSUBGROUPS_H
 
 #include "typedef.h"
 

--- a/include/typedef.h
+++ b/include/typedef.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_TYPEDEF_H_
-#define CARAT_TYPEDEF_H_
+#ifndef CARAT_TYPEDEF_H
+#define CARAT_TYPEDEF_H
 
 /* enthaelt die globalen Variablen - und Typendeklarationen */
 #include <stdio.h>
@@ -197,7 +197,7 @@ typedef struct {
 extern int INFO_LEVEL;
 
 
-#endif /* _CARAT_TYPEDEF_H_ */
+#endif /* CARAT_TYPEDEF_H */
 
 #ifdef __cplusplus
 }

--- a/include/typedef.h
+++ b/include/typedef.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _CARAT_TYPEDEF_H_
-#define _CARAT_TYPEDEF_H_
+#ifndef CARAT_TYPEDEF_H_
+#define CARAT_TYPEDEF_H_
 
 /* enthaelt die globalen Variablen - und Typendeklarationen */
 #include <stdio.h>

--- a/include/voronoi.h
+++ b/include/voronoi.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef CARAT_VORONOI_H_
-#define CARAT_VORONOI_H_
+#ifndef CARAT_VORONOI_H
+#define CARAT_VORONOI_H
 
 #include "typedef.h"
 

--- a/include/voronoi.h
+++ b/include/voronoi.h
@@ -3,8 +3,8 @@ extern "C" {
 #endif
 
 
-#ifndef _VORONOI_H_
-#define _VORONOI_H_
+#ifndef CARAT_VORONOI_H_
+#define CARAT_VORONOI_H_
 
 #include "typedef.h"
 

--- a/include/zass.h
+++ b/include/zass.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef CARAT_ZASSEN_H_
-#define CARAT_ZASSEN_H_
+#ifndef CARAT_ZASSEN_H
+#define CARAT_ZASSEN_H
 
 #include "typedef.h"
 

--- a/include/zass.h
+++ b/include/zass.h
@@ -2,8 +2,8 @@
 extern "C" {
 #endif
 
-#ifndef _ZASSEN_H_
-#define _ZASSEN_H_
+#ifndef CARAT_ZASSEN_H_
+#define CARAT_ZASSEN_H_
 
 #include "typedef.h"
 


### PR DESCRIPTION
Closes #37 

I noticed that some #include guards end with a `_` and some don't. Is there a reason for this? Otherwise I'll unify that as well and update this PR.