### PR TITLE
Add .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: no
+    patch: no
+    changes: no
+
+comment:
+  layout: "header, diff, changes, tree"
+  behavior: default


### PR DESCRIPTION
This changes the codecov config so that coverage does not affect the status of PRs; i.e., a PR which has "under average" coverage for the code it touches is not marked as failing. While doing that might be good for a project which has close to 100% coverage, it's bad for us, as a lot of the code still is not covered at all, so many PRs that just cleanup stuff get flagged.

In fact, do not "flag" PRs over coverage at all. We want the coverage reports, we look at them, but we don't want to be artificially blocked by them right now.

Finally, don't show the "reach graph", which might look pretty, but otherwise is mostly devoid of useful information.