### PR TITLE
Fix allocation sizes, reported by clang static analyzer

### DIFF
--- a/functions/Bravais/rform.c
+++ b/functions/Bravais/rform.c
@@ -103,7 +103,7 @@ rmattrans (double **A, double **B, double **C, int n)
 	int	i, j, k;
 
 
-	if ((D = (double**)malloc(n * sizeof(double))) == 0)
+	if ((D = (double**)malloc(n * sizeof(double *))) == 0)
 		exit (2);
 	for (i = 0; i < n; ++i)
 	{

--- a/functions/Datei/gittstab.c
+++ b/functions/Datei/gittstab.c
@@ -165,7 +165,7 @@ Z_class (bravais_TYP *B, matrix_TYP *zen)
      C->gen[i] = B->cen[i];
   if(C->gen_no > 0)
   CS = gittstabneu(C, zen);
-   S->form = (matrix_TYP **) malloc(B->form_no *sizeof(matrix_TYP));
+   S->form = (matrix_TYP **) malloc(B->form_no *sizeof(matrix_TYP *));
    S->form_no = B->form_no;
    ztr = init_mat(zen->cols, zen->rows, "");
    for(i=0; i<zen->rows; i++)
@@ -188,7 +188,7 @@ Z_class (bravais_TYP *B, matrix_TYP *zen)
    if(C->gen_no > 0)
    {
    S->cen_no = CS->gen_no;
-   S->cen = (matrix_TYP **) malloc(S->cen_no *sizeof(matrix_TYP));
+   S->cen = (matrix_TYP **) malloc(S->cen_no *sizeof(matrix_TYP *));
    for(i=0; i<CS->gen_no; i++)
    {
       A1 = mat_mul(zinv, CS->gen[i]);
@@ -239,7 +239,7 @@ Z_class (bravais_TYP *B, matrix_TYP *zen)
    if(anz == 0)
      anz = 1;
    S->normal_no = anz;
-   S->normal = (matrix_TYP **) malloc(S->normal_no *sizeof(matrix_TYP));
+   S->normal = (matrix_TYP **) malloc(S->normal_no *sizeof(matrix_TYP *));
 
    anz = 0;
    for(i=0; i<NS->gen_no; i++)
@@ -263,7 +263,7 @@ Z_class (bravais_TYP *B, matrix_TYP *zen)
 	  if(B->normal_no == 1 && B->normal[0]->flags.Scalar == TRUE)
 	  {
 	     S->normal_no = 1;
-	     S->normal = (matrix_TYP **) malloc(S->normal_no *sizeof(matrix_TYP));
+	     S->normal = (matrix_TYP **) malloc(S->normal_no *sizeof(matrix_TYP *));
 	     S->normal[0] = einheitsmatrix(B->dim);
 	  }
 	  if(C->gen_no > 0) {

--- a/functions/Datei/read_symbol.c
+++ b/functions/Datei/read_symbol.c
@@ -251,7 +251,7 @@ erg->grp->zentr_no = 0;
 erg->grp->normal_no = 0;
 for(i=0; i<konstit; i++)
   erg->grp->gen_no += grps[i]->gen_no;
-erg->grp->gen = (matrix_TYP **)malloc(erg->grp->gen_no *sizeof(matrix_TYP));
+erg->grp->gen = (matrix_TYP **)malloc(erg->grp->gen_no *sizeof(matrix_TYP *));
 for(i=0; i<erg->grp->gen_no; i++)
   erg->grp->gen[i]  = init_mat(erg->grp->dim, erg->grp->dim, "");
 j=0;
@@ -340,7 +340,7 @@ for(i=0; i<konstit; i++)
   if(zerleg[i][4] > 2)
     erg->grp->cen_no ++;
 }
-erg->grp->cen = (matrix_TYP **)malloc(erg->grp->cen_no *sizeof(matrix_TYP));
+erg->grp->cen = (matrix_TYP **)malloc(erg->grp->cen_no *sizeof(matrix_TYP *));
 for(i=0; i<erg->grp->cen_no; i++)
   erg->grp->cen[i]  = init_mat(erg->grp->dim, erg->grp->dim, "");
 j=0;
@@ -419,7 +419,7 @@ for(i=0; i<konstit; i++)
           }
         }
 }
-erg->grp->normal = (matrix_TYP **)malloc(erg->grp->normal_no *sizeof(matrix_TYP));
+erg->grp->normal = (matrix_TYP **)malloc(erg->grp->normal_no *sizeof(matrix_TYP *));
 for(i=0; i<erg->grp->normal_no; i++)
   erg->grp->normal[i]  = init_mat(erg->grp->dim, erg->grp->dim, "");
 j=0;

--- a/functions/Graph/graph_tools.c
+++ b/functions/Graph/graph_tools.c
@@ -147,7 +147,7 @@ matrix_TYP **all_cocycles(matrix_TYP *relator_input,
 /* there is a special case to handle, which is the case that there
 isn't a cohomology group at all */
   if (X[0][0]->cols <1){
-     Y = (matrix_TYP **)malloc(sizeof(matrix_TYP));
+     Y = (matrix_TYP **)malloc(sizeof(matrix_TYP *));
      Y[0] = init_mat(G->gen_no * G->dim,1,"");
      anzahl[0] = 1;
      N[0] = NULL;
@@ -443,7 +443,7 @@ void cen_to_norm(bravais_TYP *G)
 
    if (G->cen_no > 0){
       G->normal = (matrix_TYP **)realloc(G->normal, 
-                  (G->cen_no + G->normal_no) * sizeof(matrix_TYP));
+                  (G->cen_no + G->normal_no) * sizeof(matrix_TYP *));
       for (i = 0; i < G->cen_no; i++){
          G->normal[G->normal_no + i] = G->cen[i];
       }

--- a/functions/Graph/normalop_o.c
+++ b/functions/Graph/normalop_o.c
@@ -207,7 +207,7 @@ static matrix_TYP *static_orbit_rep(matrix_TYP *x,
    orbit = (matrix_TYP **) malloc(speicher * sizeof(matrix_TYP*));
    orbit[0] = copy_mat(x);
    if (word_flag){
-      orb_words = (int **) malloc(speicher * sizeof(int ));
+      orb_words = (int **) malloc(speicher * sizeof(int *));
       orb_words[0] = (int *) malloc(sizeof(int));
       orb_words[0][0] = 0;
    }
@@ -255,7 +255,7 @@ static matrix_TYP *static_orbit_rep(matrix_TYP *x,
                NUMBER_OF_WORDS[0]++;
                if (NUMBER_OF_WORDS[0] % MIN_SPEICHER)
                   WORDS[0] = (int **) realloc( WORDS[0] ,
-                               (NUMBER_OF_WORDS[0]+MIN_SPEICHER) * sizeof(int));
+                               (NUMBER_OF_WORDS[0]+MIN_SPEICHER) * sizeof(int *));
             }
          }
          else{
@@ -270,7 +270,7 @@ static matrix_TYP *static_orbit_rep(matrix_TYP *x,
                orbit = (matrix_TYP **) realloc(orbit,
                                     speicher * sizeof(matrix_TYP *));
                if (word_flag){
-                  orb_words = (int **)realloc(orb_words,speicher * sizeof(int));
+                  orb_words = (int **)realloc(orb_words,speicher * sizeof(int *));
                }
             }
 

--- a/functions/Graph/stabs.c
+++ b/functions/Graph/stabs.c
@@ -308,7 +308,7 @@ matrix_TYP **calculate_S1(matrix_TYP *lattice,
    while (i < counter){
       for (j = 0; j < anz; j++){
          if (counter % 1024 == 0){
-	    list = (matrix_TYP **)realloc(list, (counter + 1024) * sizeof(int *));
+	    list = (matrix_TYP **)realloc(list, (counter + 1024) * sizeof(matrix_TYP *));
 	 }
          list[counter] = mat_mul(N[j], list[i]);
          long_col_hnf(list[counter]);

--- a/functions/Graph/sub-super-tools.c
+++ b/functions/Graph/sub-super-tools.c
@@ -65,7 +65,7 @@ void plus_translationen(bravais_TYP *G,
   hilfsmat->kgv = mat->kgv;
 
   /* create the new translationmatrices for the spacegroup */
-  G->gen = (matrix_TYP **)realloc(G->gen,(G->gen_no + mat->cols)*sizeof(matrix_TYP));
+  G->gen = (matrix_TYP **)realloc(G->gen,(G->gen_no + mat->cols)*sizeof(matrix_TYP *));
   for (i=0; i<mat->cols; i++){
      G->gen[G->gen_no + i] = copy_mat(hilfsmat);
      for (j=0; j<G->dim-1; j++)

--- a/functions/Idem/bravais_catalog.c
+++ b/functions/Idem/bravais_catalog.c
@@ -209,7 +209,7 @@ erg->grp->zentr_no = 0;
 erg->grp->normal_no = 0;
 for(i=0; i<konstit; i++)
   erg->grp->gen_no += grps[i]->gen_no;
-erg->grp->gen = (matrix_TYP **)malloc(erg->grp->gen_no *sizeof(matrix_TYP));
+erg->grp->gen = (matrix_TYP **)malloc(erg->grp->gen_no *sizeof(matrix_TYP *));
 for(i=0; i<erg->grp->gen_no; i++)
   erg->grp->gen[i]  = init_mat(erg->grp->dim, erg->grp->dim, "");
 j=0;
@@ -298,7 +298,7 @@ for(i=0; i<konstit; i++)
   if(zerleg[i][4] > 2)
     erg->grp->cen_no ++;
 }
-erg->grp->cen = (matrix_TYP **)malloc(erg->grp->cen_no *sizeof(matrix_TYP));
+erg->grp->cen = (matrix_TYP **)malloc(erg->grp->cen_no *sizeof(matrix_TYP *));
 for(i=0; i<erg->grp->cen_no; i++)
   erg->grp->cen[i]  = init_mat(erg->grp->dim, erg->grp->dim, "");
 j=0;
@@ -380,7 +380,7 @@ for(i=0; i<konstit; i++)
 
 if (erg->grp->normal_no > 0)
    erg->grp->normal = (matrix_TYP **) malloc(erg->grp->normal_no
-                                            * sizeof(matrix_TYP));
+                                            * sizeof(matrix_TYP *));
 else
    erg->grp->normal = NULL;
 

--- a/functions/Idem/centr.c
+++ b/functions/Idem/centr.c
@@ -501,7 +501,7 @@ static matrix_TYP **get_idem2(matrix_TYP **gen,int number,int *anz)
       }
    }
    else{
-      erg = (matrix_TYP **) malloc(1 * sizeof(matrix_TYP));
+      erg = (matrix_TYP **) malloc(1 * sizeof(matrix_TYP *));
       anz[0] = 1;
       erg[0] = ONE;
    }
@@ -696,7 +696,7 @@ matrix_TYP **idempotente(matrix_TYP **gen,int gen_no,matrix_TYP *form,
 
   /* put the centralizer and it's centre on the same pointer as idem */
   idem = (matrix_TYP **) realloc(idem,(anz[0]+dimc[0]+dimcc[0])
-                                     * sizeof(matrix_TYP));
+                                     * sizeof(matrix_TYP *));
   for (i=0;i<dimc[0];i++) idem[anz[0]+i] = centralizer[i];
   for (i=0;i<dimcc[0];i++) idem[anz[0]+dimc[0]+i] = ccentralizer[i];
 

--- a/functions/Idem/min_pol.c
+++ b/functions/Idem/min_pol.c
@@ -53,7 +53,7 @@ matrix_TYP *min_pol(matrix_TYP *A)
    }
 
    /* prepare all variables */
-   potenzen = (matrix_TYP **) calloc(1 + A->cols , sizeof(matrix_TYP));
+   potenzen = (matrix_TYP **) calloc(1 + A->cols , sizeof(matrix_TYP *));
    potenzen[0] = init_mat(A->cols,A->cols,"1");
    potenzen[1] = copy_mat(A);
    lines = init_MP_mat(A->cols+1,A->cols*A->cols);

--- a/functions/Longtools/long_solve_mat.c
+++ b/functions/Longtools/long_solve_mat.c
@@ -66,7 +66,7 @@ long_solve_mat (matrix_TYP *A, matrix_TYP *B)
    }
 
 
-   if((erg = (matrix_TYP **)malloc(2 *sizeof(matrix_TYP **))) == NULL)
+   if((erg = (matrix_TYP **)malloc(2 *sizeof(matrix_TYP *))) == NULL)
    {
      printf("malloc of 'erg' in 'long_solve_mat' failed\n");
      exit(2);

--- a/functions/Matrix/tools_mat.c
+++ b/functions/Matrix/tools_mat.c
@@ -343,7 +343,7 @@ int **Z;
     for(j = col; j < mat->cols - 1; j++) {
       Z[i][j] = Z[i][j+1];
     }
-    Z[i] = (int  *)realloc(Z[i], (mat->cols-1)*sizeof(int  *));
+    Z[i] = (int *)realloc(Z[i], (mat->cols-1)*sizeof(int));
   }
   
   if( mat->array.N != NULL) {
@@ -352,7 +352,7 @@ int **Z;
       for(j = col; j < mat->cols - 1; j++) {
         Z[i][j] = Z[i][j+1];
       }
-      Z[i] = (int  *)realloc(Z[i], (mat->cols-1)*sizeof(int  *));
+      Z[i] = (int *)realloc(Z[i], (mat->cols-1)*sizeof(int));
     }
   }
   

--- a/functions/Orbit/orbit_alg.c
+++ b/functions/Orbit/orbit_alg.c
@@ -506,7 +506,7 @@ orbit_alg (matrix_TYP *M, bravais_TYP *G, bravais_TYP *S, int *option, int *leng
   standartisieren(M);
   h = hash_number(M);
   ergverz = hash_addbaum(M, NULL, erganz, ergverz, &schonda, h, NULL);
-  erg = (matrix_TYP **)malloc(EXT_SIZE *sizeof(matrix_TYP));
+  erg = (matrix_TYP **)malloc(EXT_SIZE *sizeof(matrix_TYP *));
   erg[0] = init_mat(M->rows, M->cols, "");
   hashverz = (int *)malloc(EXT_SIZE *sizeof(int));
     hashverz[0] = h;

--- a/functions/Polyeder/refine_fuber.c
+++ b/functions/Polyeder/refine_fuber.c
@@ -283,7 +283,7 @@ int refine_fund_domain(fund_domain *F, wall_TYP *h)
 
  p=0;n=0;
  old_no = F->vert_no;
- count = (int *)malloc(F->vert_no *sizeof(int *));
+ count = (int *)malloc(F->vert_no *sizeof(int));
  for(i=0;i<F->vert_no;i++)
   count[i] = 0;
  for(i=0;i<old_no;i++)

--- a/functions/Polyeder/refine_polyeder.c
+++ b/functions/Polyeder/refine_polyeder.c
@@ -279,7 +279,7 @@ refine_polyeder (polyeder_TYP *F, wall_TYP *h)
  p=0;n=0;
  z=0;
  old_no = F->vert_no;
- count = (int *)malloc(F->vert_no *sizeof(int *));
+ count = (int *)malloc(F->vert_no *sizeof(int));
  for(i=0;i<F->vert_no;i++)
   count[i] = 0;
  for(i=0;i<old_no;i++)

--- a/functions/TSubgroups/tSUPERgroups_fct_db.c
+++ b/functions/TSubgroups/tSUPERgroups_fct_db.c
@@ -125,7 +125,7 @@ static bravais_TYP **get_supergr(char *pfad,
 	          Sstd = get_std_rep(pfad, NameSstd);
                   Sstdinv = init_bravais(Sstd->dim);
                   Sstdinv->gen_no = Sstd->gen_no;
-                  Sstdinv->gen = (matrix_TYP **)calloc(Sstd->gen_no, sizeof(bravais_TYP *));
+                  Sstdinv->gen = (matrix_TYP **)calloc(Sstd->gen_no, sizeof(matrix_TYP *));
                   for (j = 0; j < Sstd->gen_no; j++)
                      Sstdinv->gen[j] = mat_inv(Sstd->gen[j]);
                }

--- a/functions/TSubgroups/tsubgroups_fct.c
+++ b/functions/TSubgroups/tsubgroups_fct.c
@@ -169,14 +169,14 @@ TSubgroup_TYP **tsubgroup(bravais_TYP *R,
    S = (TSubgroup_TYP **)calloc(no[0], sizeof(TSubgroup_TYP *));
    Rinv = init_bravais(R->dim);
    Rinv->gen_no = R->gen_no;
-   Rinv->gen = (matrix_TYP **)calloc(R->gen_no, sizeof(bravais_TYP *));
+   Rinv->gen = (matrix_TYP **)calloc(R->gen_no, sizeof(matrix_TYP *));
    for (i = 0; i < R->gen_no; i++){
       Rinv->gen[i] = mat_inv(R->gen[i]);
    }
    if (aflag){
       Pinv = init_bravais(P->dim);
       Pinv->gen_no = P->gen_no;
-      Pinv->gen = (matrix_TYP **)calloc(P->gen_no, sizeof(bravais_TYP *));
+      Pinv->gen = (matrix_TYP **)calloc(P->gen_no, sizeof(matrix_TYP *));
       for (i = 0; i < P->gen_no; i++){
          Pinv->gen[i] = mat_inv(P->gen[i]);
       }

--- a/functions/TSubgroups/tsubgroups_fct_db.c
+++ b/functions/TSubgroups/tsubgroups_fct_db.c
@@ -86,7 +86,7 @@ TSubgroup_TYP **tsubgroup_db(bravais_TYP *R,
          inv = mat_inv(Name.trafo);
          Rinv = init_bravais(Rstd->dim);
          Rinv->gen_no = Rstd->gen_no;
-         Rinv->gen = (matrix_TYP **)calloc(Rstd->gen_no, sizeof(bravais_TYP *));
+         Rinv->gen = (matrix_TYP **)calloc(Rstd->gen_no, sizeof(matrix_TYP *));
          for (k = 0; k < Rstd->gen_no; k++){
             Rinv->gen[k] = mat_inv(Rstd->gen[k]);
          }

--- a/functions/Voronoi/bravais_flok.c
+++ b/functions/Voronoi/bravais_flok.c
@@ -510,7 +510,7 @@ matrix_TYP *is_z_equivalent(bravais_TYP *G,bravais_TYP *G_tr,
                /* there is an isometry, let's see whether it respects the
                   neighbours also */
                /* now calculate all perfect neigbours of hperfect */
-               gneighbours = (matrix_TYP **) malloc(sizeof(matrix_TYP));
+               gneighbours = (matrix_TYP **) malloc(sizeof(matrix_TYP *));
                gneighbours[0] = gp[i]->gram;
                anz_gneighbours = neighbours(&gneighbours,G,G_tr->form,gtrbifo,
                                                         GSV,ming);

--- a/functions/Voronoi/bravais_flok_datei.c
+++ b/functions/Voronoi/bravais_flok_datei.c
@@ -212,7 +212,7 @@ matrix_TYP *is_z_equivalent_datei(bravais_TYP *G,bravais_TYP *G_tr,
                ming = minh;
 
                /* now calculate all perfect neigbours of hperfect */
-               gneighbours = (matrix_TYP **) malloc(sizeof(matrix_TYP));
+               gneighbours = (matrix_TYP **) malloc(sizeof(matrix_TYP *));
                gneighbours[0] = gp[0][i]->gram;
                anz_gneighbours = neighbours(&gneighbours,G,G_tr->form,gtrbifo,
                                                         GSV,ming);

--- a/functions/ZZ/q2z.c
+++ b/functions/ZZ/q2z.c
@@ -618,7 +618,7 @@ bravais_TYP **q2z(bravais_TYP *G,
       GROUPS[0]->normal = GL_n_Z(G->dim,&GROUPS[0]->normal_no);
       *number = 1;
       if (ADFLAG){
-          GROUPS[0]->zentr = (matrix_TYP **) malloc(1 * sizeof(matrix_TYP));
+          GROUPS[0]->zentr = (matrix_TYP **) malloc(1 * sizeof(matrix_TYP *));
           GROUPS[0]->zentr[0] = init_mat(G->dim,G->dim,"1");
           GROUPS[0]->zentr_no = 1;
       }

--- a/functions/Zassen/normalop.c
+++ b/functions/Zassen/normalop.c
@@ -206,7 +206,7 @@ matrix_TYP *orbit_rep(matrix_TYP *x,
    orbit = (matrix_TYP **) malloc(speicher * sizeof(matrix_TYP*));
    orbit[0] = copy_mat(x);
    if (word_flag){
-      orb_words = (int **) malloc(speicher * sizeof(int ));
+      orb_words = (int **) malloc(speicher * sizeof(int *));
       orb_words[0] = (int *) malloc(sizeof(int));
       orb_words[0][0] = 0;
    }
@@ -254,7 +254,7 @@ matrix_TYP *orbit_rep(matrix_TYP *x,
                NUMBER_OF_WORDS[0]++;
                if (NUMBER_OF_WORDS[0] % MIN_SPEICHER)
                   WORDS[0] = (int **) realloc( WORDS[0] ,
-                               (NUMBER_OF_WORDS[0]+MIN_SPEICHER) * sizeof(int));
+                               (NUMBER_OF_WORDS[0]+MIN_SPEICHER) * sizeof(int *));
             }
          }
          else{
@@ -269,7 +269,7 @@ matrix_TYP *orbit_rep(matrix_TYP *x,
                orbit = (matrix_TYP **) realloc(orbit,
                                     speicher * sizeof(matrix_TYP *));
                if (word_flag){
-                  orb_words = (int **)realloc(orb_words,speicher * sizeof(int));
+                  orb_words = (int **)realloc(orb_words,speicher * sizeof(int *));
                }
             }
 

--- a/functions/Zassen/reget_gen.c
+++ b/functions/Zassen/reget_gen.c
@@ -193,7 +193,7 @@ matrix_TYP *reget_gen(matrix_TYP **map,int number,bravais_TYP *G,
                set the matrix and the word */
                ele[length] = tmp;
                ele_words[length] = (int *) malloc((ele_words[i][0]+2)
-                                               * sizeof(int*));
+                                               * sizeof(int));
                memcpy(ele_words[length],ele_words[i],
                       (ele_words[i][0]+1) * sizeof(int));
                ele_words[length][0] = ele_words[i][0]+1;

--- a/src/orbit.c
+++ b/src/orbit.c
@@ -119,7 +119,7 @@ int main (int argc, char *argv[])
 
             if (mat_search(M[i],erg,length,mat_comp) == -1){
                tmp = orbit_alg(M[i],G, Stab, option, &l);
-               erg = (matrix_TYP **) realloc(erg,(length+l)*sizeof(matrix_TYP));
+               erg = (matrix_TYP **) realloc(erg,(length+l)*sizeof(matrix_TYP *));
                for (j=0;j<l;j++){
                   erg[length+j] = tmp[j];
                }


### PR DESCRIPTION
The TYPE sizeof(TYPE) in the size computation for malloc/realloc calls
did not fit the actual return type. In most cases, this luckily resulted
in no bugs and at worst some overallocation.

But in a few places, we used `sizeof(int)` instead of `sizeof(int *)`, and
on 64 bit systems, that could result in a too small allocation.

Was part of PR #77