### PR TITLE
Remove GAP package from the title of the website.

### DIFF
--- a/_data/package.yml
+++ b/_data/package.yml
@@ -27,7 +27,7 @@ contributors:
 
 
 needed-pkgs:
-    - name: "gcc"
+    - name: "A C compiler, for example gcc"
       version: ""
       url: "https://gcc.gnu.org"
 

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-# GAP Package {{site.data.package.name}}
+# {{site.data.package.name}}
 
 {{site.data.package.abstract}}
 


### PR DESCRIPTION
Also, change the dependencies to say we need a C compiler, for example
gcc, as we don't specifically need gcc.