### PR TITLE
Avoid a use after free

### DIFF
--- a/functions/Idem/v4_catalog.c
+++ b/functions/Idem/v4_catalog.c
@@ -380,8 +380,8 @@ bravais_TYP *catalog_number_v4(bravais_TYP *G,const char *symb,
        zclass[0] = 1;
        S = read_symbol_from_string(symb);
        T = S->grp;
-       free(S);
        free(S->fn);
+       free(S);
        TR[0] = init_mat(G->dim,G->dim,"1");
        if (T->zentr_no > 0){
           fprintf(stderr,"catalog_number: an error ocurred in the -I_n case\n");


### PR DESCRIPTION
Recent versions of GCC have `-Wuse-after-free` (implied by `-Wall`).  That warning produces this output:
```
functions/Idem/v4_catalog.c: In function 'catalog_number_v4':
functions/Idem/v4_catalog.c:384:14: warning: pointer used after 'free' [-Wuse-after-free]
  384 |        free(S->fn);
      |             ~^~~~
functions/Idem/v4_catalog.c:383:8: note: call to 'free' here
  383 |        free(S);
      |        ^~~~~~~

```
This commit reverses the order of the 2 `free` statements to avoid a use after free.
